### PR TITLE
Use a pipe instead of > to define command

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -63,7 +63,7 @@
       when: github_pr_login.rc == 0
       args:
         executable: /bin/bash
-      shell: >
+      shell: |
         GITHUB_PR_REPO="{{ github_pr_repo.stdout }}"
         GITHUB_PR_ORG="{{ github_pr_org.stdout }}"
         GITHUB_PR_LOGIN="{{ github_pr_login.stdout }}"


### PR DESCRIPTION
When using the > character, a yaml multi line string is
joined with spaces and quoted. When a multi-line is
separated with a | character, the lines are joined with a
new line