### PR TITLE
Drop http(s)_proxy env vars

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -46,8 +46,6 @@
       tox_environment:
         HTTP_PROXY: "http://squid.internal:3128"
         HTTPS_PROXY: "http://squid.internal:3128"
-        http_proxy: "http://squid.internal:3128"
-        https_proxy: "http://squid.internal:3128"
 - job:
     name: openstack-tox-snap-with-sudo
     parent: openstack-tox-with-sudo


### PR DESCRIPTION
These appear to be conflicting with HTTP(S)_PROXY and microstack
lxd builds.