### PR TITLE
Add support for building a reactive charm and archiving that

### DIFF
--- a/playbooks/charm/build.yaml
+++ b/playbooks/charm/build.yaml
@@ -1,4 +1,6 @@
 - hosts: all
+  roles:
+    - charm-build
   tasks:
     - name: Check if charm is source charm
       shell: |
@@ -7,39 +9,31 @@
         executable: /bin/bash
       register: charm_buildable
       failed_when: false
-    - name: 'source charm'
-      when: charm_buildable.rc == 0
-      command: "{{ tox_executable }} -e build"
-      # set_fact:
-      #   charm_path: "{{ zuul.project.src_dir }}/builds/build/{{ zuul.project.short_name }}"
-    # TODO evaluate saving the built charm as an artifact:
-    # 
-    # - name: Find built charm
-    #   when: charm_buildable.rc == 0
-    #   find:
-    #     file_type: directory
-    #     # paths: "src/{{ zuul.project.canonical_name }}/dist"
-    #     paths: "build/builds"
-    #   register: result
-    # - name: Return built charm to Zuul
-    #   loop: "{{ result.files }}"
-    #   zuul_return:
-    #     data:
-    #       zuul:
-    #         artifacts:
-    #           - name: charm
-    #             url: "{{ zuul.executor.src_root }}"
-    #           # - name: "Python wheel"
-    #           #   url: "artifacts/{{ item.path | basename }}"
-    #           #   metadata:
-    #           #     type: python_wheel
 
-    - name: 'set charm is classic'
-      when: charm_buildable.rc == 1
-      command: /bin/true
-      # zuul_return:
-      #   data:
-      #     zuul:
-      #       artifacts:
-      #         - name: charm
-      #           url: "{{ zuul.executor.src_root }}"
+    - name: archive built charm
+      when: charm_build_output.rc == 0
+      register: charm_archived
+      command: tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 -C build/builds/{{ charm_build_name }} .
+
+    - name: Upload built charm to swift
+      delegate_to: localhost
+      when: charm_archived.rc == 0
+      zuul_swift_upload:
+        cloud: "{{ serverstack_cloud }}"
+        partition: "true"
+        container: "zuul"
+        public: "yes"
+        prefix: "built_charms"
+        indexes: "false"
+        files:
+          - {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2
+        delete_after: "14"
+      set_fact: charm_uploaded
+      tasks:
+        - zuul_return:
+          data:
+            zuul:
+              artifacts:
+                - name: built charm tarball
+                  type: charm
+                  url: http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2

--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -1,23 +1,25 @@
-# - name: get ip
-#   shell: ip a | grep 10.5 | awk '{print $2}' | awk -F '/' '{print $1}'
-#   args:
-#     executable: /bin/bash
-#   register: ip_out
-# - name: set test VIP CIDR
-#   set_fact:
-#     network: 172.16.{{ ip_out.stdout.split('.')[-1] }}
-# - name: set CIDR ext
-#   set_fact:
-#     cidr_ext: "{{ network }}.0/24"
-# - debug:
-#     var: network
-# - debug:
-#     var: cidr_ext
-
-
-
-- name: build charm
+# Improvements: use the built charm tarball artifact that's sent to Zuul for
+# downloading rather than just knowing the path and using that.
+- name: fetch charm
   when: needs_charm_build
+  command: |
+    wget http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 || true
+    mkdir {{ zuul.project.src_dir }}/build/builds/{{ charm_build_name }}
+    cd {{ zuul.project.src_dir }}/build/builds/{{ charm_build_name }}
+    # try to untar the downloaded file and echo our "success" message, but pass on failure
+    tar xjf ../{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 && \
+      echo "successfully fetched built {{ charm_build_name }}" || \
+      true
+  register: fetch_charm
+
+# In the below conditional, we're asking to build the charm with two conditions:
+# 1. The charm is a reactive charm that's been configured to build (needs_charm_build)
+# 2. We did not successfully fetch a built charm in the step above.
+#      The way we're checking if we fetched successfully is to look through the output of
+#      the previous command for the string "successfully fetched built" and checking the
+#      position of that, as -1 is the value for a not-found in this case.
+- name: build charm
+  when: needs_charm_build and fetch_charm.stdout.find("successfully fetched built") == -1
   args:
     chdir: "{{ zuul.project.src_dir }}"
   environment: "{{ tox_environment|combine(tox_constraints_env|default({})) }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -81,12 +81,14 @@
       tox_envlist: py35
       python_version: 3.5
 
-# - job:
-#     name: charm-build
-#     description: Build a source charm into a deployable charm
-#     parent: tox
-#     provides: charm
-#     run: playbooks/charm/build.yaml
+- job:
+    name: charm-build
+    description: Build a source charm into a deployable charm
+    parent: tox
+    provides: charm
+    run: playbooks/charm/build.yaml
+    secrets:
+      - serverstack_cloud
 
 - job:
     name: configure-juju


### PR DESCRIPTION
This change introduces a new playbook that can be integrated into the
build pipeline to build and archive a reactive charm to allow for later
jobs to retrieve it. The existing build step should then work to either download
the built artifact or build it if missing.

This fallback code path allows reusing the existing charm-build role in the new
playbook because we can import the existing role (`charm-build`) in the
charm build playbook and it will correctly build the charm. At that point, the
playbook will archive the built artifact under a build-specific identifier
generated by zuul in Serverstack's Swift.