### PR TITLE
Add support for fetching the trilio vault license from Swift

### DIFF
--- a/playbooks/juju/run.yaml
+++ b/playbooks/juju/run.yaml
@@ -3,4 +3,5 @@
     - revoke-sudo
     - setup-networking-env
     - charm-build
+    - setup-test-fixtures
     - tox

--- a/roles/setup-test-fixtures/tasks/main.yaml
+++ b/roles/setup-test-fixtures/tasks/main.yaml
@@ -1,0 +1,4 @@
+- name: Setup Trilio Vault license
+  get_url:
+    url: "http://10.245.161.162/swift/v1/licenses/Canonical_Engineering_NFR_100_nodes_12312022.lic"
+    dest: /tmp/tvault-license.lic

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -204,6 +204,7 @@
         TEST_IRONIC_DEPLOY_INITRD: 'http://10.245.161.162/swift/v1/images/ironic-python-agent.initramfs'
         TEST_IRONIC_DEPLOY_VMLINUZ: 'http://10.245.161.162/swift/v1/images/ironic-python-agent.kernel'
         TEST_IRONIC_RAW_BM_IMAGE: 'http://10.245.161.162/swift/v1/images/baremetal-ubuntu-focal.img'
+        TEST_TRILIO_LICENSE: /tmp/tvault-license.lic
       tox_envlist: func-target
     secrets:
       - serverstack_cloud


### PR DESCRIPTION
This change introduces a new Role that can be
use to encapsulate all of our "get this test
file from storage and put it somewhere" type
of setup tasks.