### PR TITLE
Revoke sudo after charm build

### DIFF
--- a/playbooks/juju/run.yaml
+++ b/playbooks/juju/run.yaml
@@ -1,7 +1,7 @@
 - hosts: all
   roles:
+    - charm-build
     - revoke-sudo
     - setup-networking-env
-    - charm-build
     - setup-test-fixtures
     - tox


### PR DESCRIPTION
Charm build sometimes has additional dependencies so
we need to be able to install those before running