### PR TITLE
Fix line breaks in juju bootstrap command

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -119,7 +119,7 @@
         /snap/bin/juju bootstrap \
           --bootstrap-constraints="virt-type=kvm cores=4 mem=8G" \
           --constraints=virt-type=kvm \
-          --auto-upgrade=false
+          --auto-upgrade=false \
           --model-default=/tmp/charm-test-infra/juju-configs/model-default-serverstack.yaml \
           --config=/tmp/charm-test-infra/juju-configs/controller-default.yaml \
           {{ serverstack_cloud.region_name }}/{{ serverstack_cloud.region_name }}


### PR DESCRIPTION
Because this isn't using bash, it is probably just
a cosmetic change; however, we should have commands
that are safe to run in any shell rather than hoping
for a correct interpretation.