### PR TITLE
Add experimental pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -53,3 +53,21 @@
     failure:
       gerrit: {}
         # Verified: -1
+
+- pipeline:
+    name: experimental
+    description: |
+      On-demand pipeline for requesting a run against a set of jobs that are
+      not yet gating. Leave a review comment of "check experimental"
+    success-message: Build succeeded (experimental pipeline).
+    failure-message: Build failed (experimental pipeline).
+    manager: independent
+    precedence: low
+    trigger:
+      gerrit:
+        - event: comment-added
+          comment: (?i)^(Patch Set [0-9]+:)?( [\w\\+-]*)*(\n\n)?\s*check experimental\s*$
+      success:
+        gerrit: {}
+      failure:
+        gerrit: {}


### PR DESCRIPTION
Some features within projects like microstack are currently experimental
and the gate continues to have problems due to experimental feature
support (i.e. lvm volumes). Add an experimental pipeline which allows
the experimental tests to be run, but are non-voting tests.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>