### PR TITLE
Fix yaml formatting error

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -47,11 +47,11 @@
             - Workflow: 1
     # TODO: Re-enable voting when we're confident
     success:
-      gerrit: {}
+      gerrit:
         # Note that gerrit keywords are case-sensitive.
         Verified: 1
     failure:
-      gerrit: {}
+      gerrit:
         Verified: -1
 
 - pipeline:


### PR DESCRIPTION
Commit 0af73f36 has an error in the formatting. The Verified
voting line was uncommented, but the dictionary {} left for
the gerrit config.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>