### PR TITLE
post: Retrieve Apache and HAProxy config in crashdump

### DIFF
--- a/playbooks/juju/post.yaml
+++ b/playbooks/juju/post.yaml
@@ -11,7 +11,9 @@
       shell: |
         set -o pipefail
         for model in $(juju models | grep zaza- | awk '{gsub(/\*?/,""); print $1}'); do
-          juju-crashdump -o "{{ zuul.project.src_dir }}/log" -m $model
+          juju-crashdump -o "{{ zuul.project.src_dir }}/log" -m $model \
+            /etc/apache2 \
+            /etc/haproxy
         done
       when: not zuul_success | bool
     - name: juju status


### PR DESCRIPTION
Juju crashdump is conservative when it comes to retrieving data
from /etc. Add apache2 and haproxy subdirectories to help debug
a class of issues.

Related-Bug: #1930654