### PR TITLE
jobs/func-target: Increase default job timeout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -106,7 +106,7 @@
     name: func-target
     description: Run a functional test
     parent: configure-juju
-    timeout: 7200
+    timeout: 10800
     attempts: 2
     semaphore: functional-test
     # as an alternate to semaphores, or along side them, we could define


### PR DESCRIPTION
The default timeout of two hours is unfortunately not enough and
lead to false negative test results.

Example timeout: https://openstack-ci-reports.ubuntu.com/artifacts/f94/778991/12/check/focal-victoria-ha-ovn/f94976f/index.html