### PR TITLE
Adjust job timeout to avoid premature failures

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -38,6 +38,7 @@
 - job:
     name: openstack-tox-with-sudo
     parent: tox
+    timeout: 14400
     description: |
       Job to run tox for tests with OpenStack project specific
       settings such as constraints but without sudo access being revoked.


### PR DESCRIPTION
MicroStack jobs seem to have started taking more than 2 hours. Let's
adjust it to avoid premature failures while we figure possible test
infra changes that might have caused it.