### PR TITLE
Set the zuul_work_dir by build type

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -38,7 +38,12 @@
     {{ tox_executable }} -e build
   register: charm_build_output
 
-- name: set built charm path
-  when: needs_charm_build
+- name: set built charm path for reactive charms
+  when: needs_charm_build and build_type == "reactive"
   set_fact:
     zuul_work_dir: "{{ zuul.project.src_dir }}/build/builds/{{ charm_build_name }}"
+
+- name: set built charm path for charmcraft charms
+  when: needs_charm_build and build_type == "charmcraft"
+  set_fact:
+    zuul_work_dir: "{{ zuul.project.src_dir }}"


### PR DESCRIPTION
Set the zuul_work_dir by charm build type rather than assuming its
a reactive charm. Example failure *1

*1 https://openstack-ci-reports.ubuntu.com/artifacts/f83/803940/6/check/focal/f83c48d/job-output.json