### PR TITLE
Fix upload step

### DIFF
--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -1,19 +1,19 @@
-- name: archive built charm
+- name: archive reactive built charm
   when: charm_build_output.rc == 0 and build_type == "reactive"
-  register: charm_archived
+  register: charm_archived_reactive
   args:
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
     tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 -C build/builds/{{ charm_build_name }} .
-- name: archive built charm
+- name: archive charmcraft built charm
   when: charm_build_output.rc == 0 and build_type == "charmcraft"
-  register: charm_archived
+  register: charm_archived_charmcraft
   args:
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
-    tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' .
+    tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
 - name: fetch built charm
   synchronize:
     dest: "{{ zuul.executor.log_root }}"
@@ -24,7 +24,8 @@
     group: no
 - name: Upload built charm to swift
   delegate_to: localhost
-  when: charm_archived.rc == 0
+  when: (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or
+        (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0)
   zuul_swift_upload:
     cloud: "{{ serverstack_cloud }}"
     partition: "false"


### PR DESCRIPTION
Commit f728f884e changed the archive built charm step. After that
commit two tasks both register the charm_archived variable. Which
task is run depends on the `when` clause. The problem with this is
that the second task always overwrites the contents of `charm_archived`
even if the tasks `when` condition is not met. If the second task is
skipped then `charm_archived` is a boolean set to False. If the task
runs `charm_archived` is a dict containing the return code of the tar
command. If the second task is skipped then a subsequent task fails
because it assume `charm_archived` to be a dict *1

This patch changes the archive tasks to register different variables
and then updates the upload task to check both variables.

There is also a drive-by fix to the charmcraft tar step to stop
it including the tar ball in the tar ball.

*1 https://openstack-ci-reports.ubuntu.com/artifacts/45f/805079/1/check/charm-build/45f050d/job-output.json