### PR TITLE
Remove index.html from generated artifact links

### DIFF
--- a/roles/upload-swift/tasks/main.yaml
+++ b/roles/upload-swift/tasks/main.yaml
@@ -36,7 +36,7 @@
       zuul_return:
         data:
           zuul:
-            log_url: "https://openstack-ci-reports.ubuntu.com/artifacts{{ upload_results.url.split('uosci-artifacts') | last }}/index.html"
+            log_url: "https://openstack-ci-reports.ubuntu.com/artifacts{{ upload_results.url.split('uosci-artifacts') | last }}"
     - name: Print upload failures
       debug:
         var: upload_results.upload_failures


### PR DESCRIPTION
This coincides with an update to our swift buckets to allow all of the
listings to work correctly (/ -> index.html).