### PR TITLE
Remove groovy-victoria from charm-functional-jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ and these functional jobs:
 
 ```
 - hirsute-wallaby
-- groovy-victoria
 - focal-wallaby
 - focal-victoria
 - focal-ussuri-ec

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -45,7 +45,6 @@
     check:
       jobs:
         - hirsute-wallaby
-        - groovy-victoria
         - focal-wallaby
         - focal-victoria
         - focal-ussuri


### PR DESCRIPTION
charm-functional-jobs is the 'default' set of jobs for gate-testing
charms.  Remove groovy-victoria as it is now EOL.