### PR TITLE
Add charm-build to the charm-unit-jobs template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -59,6 +59,7 @@
       The default set of unit tests and lint checks for the OpenStack Charms
     check:
       jobs:
+        - charm-build
         - osci-lint
         - tox-py35
         - tox-py36


### PR DESCRIPTION
The `charm-build` job should be a safe job to run on any charm, even those
that don't need a charm built. In addition to building an artifact that's used
in later stages in the tests, `charm-build` generally also runs `charm proof`.