### PR TITLE
Tar charmcraft build charms in temp dir

### DIFF
--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -13,7 +13,10 @@
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
-    tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
+    TMP_DIR=$(mktemp -d)
+    tar -cjf ${TMPDIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
+    mv ${TMPDIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 .
+    rmdir ${TMPDIR}
 - name: fetch built charm
   synchronize:
     dest: "{{ zuul.executor.log_root }}"


### PR DESCRIPTION
The charmcraft build outputs to the current directory so the tar
is of the current directory too unlike reactive charms which are
built in a subdirectory and the tar ball created from a few directories
up.

Although the charm being built should be excluded from the archive
sometimes `tar: .: file changed as we read it ` errors are seen.
To guard against this build the tar ball in a seperate directory.