### PR TITLE
Fix uploading charmcraft built charms

### DIFF
--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -13,10 +13,11 @@
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
-    TMP_DIR=$(mktemp -d)
-    tar -cjf ${TMPDIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
-    mv ${TMPDIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 .
-    rmdir ${TMPDIR}
+    TMP_DIR="/tmp/{{ zuul.buildset }}"
+    mkdir $TMP_DIR
+    tar -cjf $TMPDIR/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude='*.tar.bz2' .
+    mv $TMPDIR/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 .
+    rmdir $TMPDIR
 - name: fetch built charm
   when: needs_charm_build and (
           (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or


### PR DESCRIPTION
Currently uploading charmcraft built charms is failing.
The TMP_DIR appears to either not be being set (problem with
subprocessing from withing the shell block ?) or the
use of '{}' around the variable name is causing some conflict
with ansible. Since the zuul.buildset is already unique
this can be used to create the temporary tar dir rather
than relying on subprocessing out to mktmp. Also, remove
the '{}' around TMP_DIR incase thats causing an issue.

Failure this PR is deesigned to fix:

`TASK [upload-charm : archive charmcraft built charm]
tar (child): /openstack-loadbalancer-c51deac418ba4b7f900537b6ef96928d.tar.bz2: Cannot open: Permission denied
tar (child): Error is not recoverable: exiting now
mv: cannot stat '/openstack-loadbalancer-c51deac418ba4b7f900537b6ef96928d.tar.bz2': No such file or directory
rmdir: missing operand`