### PR TITLE
Only upload built .charm file for charmcraft charms

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -9,8 +9,8 @@
     name: libmysqlclient-dev
 # Improvements: use the built charm tarball artifact that's sent to Zuul for
 # downloading rather than just knowing the path and using that.
-- name: fetch charm
-  when: needs_charm_build
+- name: fetch reactive charm
+  when: needs_charm_build and build_type == "reactive"
   args:
     executable: /bin/bash
   shell: |
@@ -21,6 +21,15 @@
     tar xjf /tmp/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 && \
       echo "successfully fetched built {{ charm_build_name }}" || \
       true
+  register: fetch_charm
+
+- name: fetch charmcraft charm
+  when: needs_charm_build and build_type == "charmcraft"
+  args:
+    executable: /bin/bash
+  shell: |
+    set -x
+    curl -o {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm http://10.245.161.162:80/swift/v1/zuul-built-charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm || true
   register: fetch_charm
 
 # In the below conditional, we're asking to build the charm with two conditions:

--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -13,14 +13,11 @@
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
-    TMP_DIR=$(mktemp -d)
-    tar -cjf ${TMP_DIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
-    mv ${TMP_DIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 .
-    rmdir ${TMP_DIR}
-- name: fetch built charm
-  when: needs_charm_build and (
-          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or
-          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0))
+    set -x
+    mv {{ charm_build_name }}.charm {{ charm_build_name }}-{{ zuul.buildset }}.charm
+- name: fetch built reactive charm
+  when: needs_charm_build and
+          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0)
   synchronize:
     dest: "{{ zuul.executor.log_root }}"
     mode: pull
@@ -28,11 +25,20 @@
     verify_host: true
     owner: no
     group: no
-- name: Upload built charm to swift
+- name: fetch built charmcraft charm
+  when: needs_charm_build and
+          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0)
+  synchronize:
+    dest: "{{ zuul.executor.log_root }}"
+    mode: pull
+    src: "{{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm"
+    verify_host: true
+    owner: no
+    group: no
+- name: Upload built reactive charm to swift
   delegate_to: localhost
-  when: needs_charm_build and (
-          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or
-          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0))
+  when: needs_charm_build and
+          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0)
   zuul_swift_upload:
     cloud: "{{ serverstack_cloud }}"
     partition: "false"
@@ -43,10 +49,25 @@
     files:
       - "{{ zuul.executor.log_root }}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2"
     delete_after: "2592000"
-  register: upload_results
+  register: upload_results_reactive
+- name: Upload built charmcraft charm to swift
+  delegate_to: localhost
+  when: needs_charm_build and
+          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0)
+  zuul_swift_upload:
+    cloud: "{{ serverstack_cloud }}"
+    partition: "false"
+    container: "zuul-built-charms"
+    public: "yes"
+    prefix: ""
+    indexes: "false"
+    files:
+      - "{{ zuul.executor.log_root }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm"
+    delete_after: "2592000"
+  register: upload_results_charmcraft
 
 - block:
-    - name: Return charm to Zuul
+    - name: Return reactive charm to Zuul
       delegate_to: localhost
       zuul_return:
         data:
@@ -57,5 +78,19 @@
               url: http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2
     - name: Print upload failures
       debug:
-        var: upload_results.upload_failures
-  when: upload_results is defined
+        var: upload_results_reactive.upload_failures
+  when: upload_results_reactive is defined and build_type == "reactive"
+- block:
+    - name: Return charmcraft charm to Zuul
+      delegate_to: localhost
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+            - name: built charmcraft charm
+              type: charm
+              url: http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm
+    - name: Print upload failures
+      debug:
+        var: upload_results_charmcraft.upload_failures
+  when: upload_results_charmcraft is defined and build_type == "charmcraft"


### PR DESCRIPTION
611f6c1 and 32c0131 were reverted due to a non-fatal error in
handling upload debug logs:

`
2021-10-05 09:23:23.942868 | TASK [upload-charm : Print upload failures]
2021-10-05 09:23:24.075925 | xenial-medium | ok:
2021-10-05 09:23:24.076302 | xenial-medium | {
2021-10-05 09:23:24.076406 | xenial-medium |   "upload_results_reactive.upload_failures": "VARIABLE IS NOT DEFINED!: 'dict object' has no attribute 'upload_failures'"
2021-10-05 09:23:24.076500 | xenial-medium | }
`

https://openstack-ci-reports.ubuntu.com/artifacts/6dd/811998/2/check/charm-build/6dd1ac0/job-output.txt

This PR contains the changes from 611f6c1 and 32c0131. In addition
the 'Return (charmcraft|reactive) charm to Zuul' job definitions
now have a charm type conditional.