### PR TITLE
Only upload built .charm file for charmcraft charms

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -9,8 +9,8 @@
     name: libmysqlclient-dev
 # Improvements: use the built charm tarball artifact that's sent to Zuul for
 # downloading rather than just knowing the path and using that.
-- name: fetch charm
-  when: needs_charm_build
+- name: fetch reactive charm
+  when: needs_charm_build and build_type == "reactive"
   args:
     executable: /bin/bash
   shell: |
@@ -21,7 +21,16 @@
     tar xjf /tmp/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 && \
       echo "successfully fetched built {{ charm_build_name }}" || \
       true
-  register: fetch_charm
+  register: fetch_charm_reactive
+
+- name: fetch charmcraft charm
+  when: needs_charm_build and build_type == "charmcraft"
+  args:
+    executable: /bin/bash
+  shell: |
+    set -x
+    curl -o {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm http://10.245.161.162:80/swift/v1/zuul-built-charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm || true
+  register: fetch_charm_charmcraft
 
 # In the below conditional, we're asking to build the charm with two conditions:
 # 1. The charm is a reactive charm that's been configured to build (needs_charm_build)
@@ -30,7 +39,9 @@
 #      the previous command for the string "successfully fetched built" and checking the
 #      position of that, as -1 is the value for a not-found in this case.
 - name: build charm
-  when: needs_charm_build and fetch_charm.stdout.find("successfully fetched built") == -1
+  when: needs_charm_build and (
+          (fetch_charm_reactive.stdout is defined and fetch_charm_reactive.stdout.find("successfully fetched built") == -1) or
+          (fetch_charm_charmcraft.stdout is defined and fetch_charm_charmcraft.stdout.find("successfully fetched built") == -1))
   args:
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash

--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -13,14 +13,11 @@
     chdir: "{{ zuul.project.src_dir }}"
     executable: /bin/bash
   shell: |
-    TMP_DIR=$(mktemp -d)
-    tar -cjf ${TMP_DIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 --exclude='.tox' --exclude='.git' --exclude='build' --exclude="*.tar.bz2" .
-    mv ${TMP_DIR}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 .
-    rmdir ${TMP_DIR}
-- name: fetch built charm
-  when: needs_charm_build and (
-          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or
-          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0))
+    set -x
+    mv {{ charm_build_name }}.charm {{ charm_build_name }}-{{ zuul.buildset }}.charm
+- name: fetch built reactive charm
+  when: needs_charm_build and
+          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0)
   synchronize:
     dest: "{{ zuul.executor.log_root }}"
     mode: pull
@@ -28,11 +25,20 @@
     verify_host: true
     owner: no
     group: no
-- name: Upload built charm to swift
+- name: fetch built charmcraft charm
+  when: needs_charm_build and
+          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0)
+  synchronize:
+    dest: "{{ zuul.executor.log_root }}"
+    mode: pull
+    src: "{{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm"
+    verify_host: true
+    owner: no
+    group: no
+- name: Upload built reactive charm to swift
   delegate_to: localhost
-  when: needs_charm_build and (
-          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0) or
-          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0))
+  when: needs_charm_build and
+          (charm_archived_reactive.rc is defined and charm_archived_reactive.rc == 0)
   zuul_swift_upload:
     cloud: "{{ serverstack_cloud }}"
     partition: "false"
@@ -43,10 +49,25 @@
     files:
       - "{{ zuul.executor.log_root }}/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2"
     delete_after: "2592000"
-  register: upload_results
+  register: upload_results_reactive
+- name: Upload built charmcraft charm to swift
+  delegate_to: localhost
+  when: needs_charm_build and
+          (charm_archived_charmcraft.rc is defined and charm_archived_charmcraft.rc == 0)
+  zuul_swift_upload:
+    cloud: "{{ serverstack_cloud }}"
+    partition: "false"
+    container: "zuul-built-charms"
+    public: "yes"
+    prefix: ""
+    indexes: "false"
+    files:
+      - "{{ zuul.executor.log_root }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm"
+    delete_after: "2592000"
+  register: upload_results_charmcraft
 
 - block:
-    - name: Return charm to Zuul
+    - name: Return reactive charm to Zuul
       delegate_to: localhost
       zuul_return:
         data:
@@ -57,5 +78,19 @@
               url: http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2
     - name: Print upload failures
       debug:
-        var: upload_results.upload_failures
-  when: upload_results is defined
+        var: upload_results_reactive.upload_failures
+  when: upload_results_reactive is defined and build_type == "reactive"
+- block:
+    - name: Return charmcraft charm to Zuul
+      delegate_to: localhost
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+            - name: built charmcraft charm
+              type: charm
+              url: http://10.245.161.162:80/swift/v1/zuul/artifacts/built_charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm
+    - name: Print upload failures
+      debug:
+        var: upload_results_charmcraft.upload_failures
+  when: upload_results_charmcraft is defined and build_type == "charmcraft"


### PR DESCRIPTION
9727ca97ef was reverted due to a fatal error when building
reactive charms:

`
2021-10-05 10:42:04.982545 | xenial-medium |   "msg": "The conditional check 'needs_charm_build and fetch_charm.stdout.find(\"successfully fetched built\") == -1' failed. The error was: error while evaluating conditional (needs_charm_build and fetch_charm.stdout.find(\"successfully fetched built\") == -1): 'dict object' has no attribute 'stdout'\n\nThe error appears to be in '/var/lib/zuul/builds/e81c9accd06b47dd836b36093e7d504c/trusted/project_0/github.com/openstack-charmers/zosci-config/roles/charm-build/tasks/main.yaml': line 41, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n#      position of that, as -1 is the value for a not-found in this case.\n- name: build charm\n  ^ here\n"
`

https://openstack-ci-reports.ubuntu.com/artifacts/e81/812464/1/check/charm-build/e81c9ac/job-output.txt

This appears to be because both the reactive and the charmcraft
fetch jobs both registered `fetch_charm`. The reactive one is
defined first and run first. The charmcraft job is run next and
the value of `fetch_charm` is overwritten even if the jobs
conditional is not met. This means when the subsequent job
tries to examine fetch_charm.stdout it finds it non-existant.

This PR contains 9727ca97ef plus defining different fetch_charm
vars for the reactive and charmcraft builds. This inturn
requires an update to the `build charm` job so that it checks
both fetch parameters.