### PR TITLE
Fix charmcraft charm being rebuilt

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -29,7 +29,9 @@
     executable: /bin/bash
   shell: |
     set -x
-    curl -o {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm http://10.245.161.162:80/swift/v1/zuul-built-charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm || true
+    curl -o {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm http://10.245.161.162:80/swift/v1/zuul-built-charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm && \
+      echo "successfully fetched built {{ charm_build_name }}" || \
+      true
   register: fetch_charm_charmcraft
 
 # In the below conditional, we're asking to build the charm with two conditions:


### PR DESCRIPTION
Charmcraft charms are being rebuilt when running functional tests
even if the built charm was sucessfully downloaded. This is because
the download step is not echoing the phrase:
"successfully fetched built" which the build step checks for.