### PR TITLE
Fix archive job if build job was skipped

### DIFF
--- a/roles/upload-charm/tasks/main.yaml
+++ b/roles/upload-charm/tasks/main.yaml
@@ -1,5 +1,5 @@
 - name: archive reactive built charm
-  when: needs_charm_build and charm_build_output.rc == 0 and build_type == "reactive"
+  when: needs_charm_build and charm_build_output.rc is defined and charm_build_output.rc == 0 and build_type == "reactive"
   register: charm_archived_reactive
   args:
     chdir: "{{ zuul.project.src_dir }}"
@@ -7,7 +7,7 @@
   shell: |
     tar -cjf {{ charm_build_name }}-{{ zuul.buildset }}.tar.bz2 -C build/builds/{{ charm_build_name }} .
 - name: archive charmcraft built charm
-  when: needs_charm_build and charm_build_output.rc == 0 and build_type == "charmcraft"
+  when: needs_charm_build and charm_build_output.rc is defined and charm_build_output.rc == 0 and build_type == "charmcraft"
   register: charm_archived_charmcraft
   args:
     chdir: "{{ zuul.project.src_dir }}"


### PR DESCRIPTION
If the build job was skipped becuase the built charm was downloaded
then the archive jobs fail as there is not build rc. This PR fixes that
in the same way as is done with other jobs by checking the rc attribute
is present first.