### PR TITLE
Run rudimentary checks on downloaded file

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -30,7 +30,8 @@
   shell: |
     set -x
     curl -o {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm http://10.245.161.162:80/swift/v1/zuul-built-charms/{{ charm_build_name }}-{{ zuul.buildset }}.charm || true
-    mv {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm {{ zuul.project.src_dir }}/{{ charm_build_name }}.charm && \
+    mv {{ zuul.project.src_dir }}/{{ charm_build_name }}-{{ zuul.buildset }}.charm {{ zuul.project.src_dir }}/{{ charm_build_name }}.charm || true
+    ls -l {{ zuul.project.src_dir }}/{{ charm_build_name }}.charm && grep -Ev 'NoSuchKey' {{ zuul.project.src_dir }}/{{ charm_build_name }}.charm && \
       echo "successfully fetched built {{ charm_build_name }}" || \
       true
   register: fetch_charm_charmcraft


### PR DESCRIPTION
Before building a charm zosci attempts to download it from swift.
If it succeeds then the build is skipped. However the download
always succeeds, if the artifact isn't present in swift the
'downloaded' charm just contains 'NoSuchKey'

```
$ curl -o /tmp/foo.charm  http://10.245.161.162:80/swift/v1/zuul-built-charms/foo.charm
$ cat /tmp/foo.charm
NoSuchKey
```

For reactive charms the charm is downloaded and then untar'd but
the untar fails which stop job from echoing the success message.
For charmcraft charms there is no untar step so the job appearts
to have correctly downloaded the charm.

This PR adds a very rudimentary check on the downloaded file
to ascertain whether the charm was downloaded correctly.