### PR TITLE
Add charm-yoga-unit-jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -65,3 +65,14 @@
         - tox-py36
         - tox-py37
         - tox-py38
+- project-template:
+    name: charm-yoga-unit-jobs
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py36
+        - tox-py38
+        - tox-py39


### PR DESCRIPTION
This adds a new job that doesn't include py35, and aligns
with https://review.opendev.org/c/openstack/openstack-zuul-jobs/+/814126/4/zuul.d/project-templates.yaml