### PR TITLE
Add jammy-yoga

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -282,6 +282,13 @@
     vars:
       tox_extra_args: bionic-queens
 - job:
+    name: jammy-yoga
+    description: Run a functional test against jammy-yoga
+    parent: func-target
+    dependences: *smoke-jobs
+    vars:
+      tox_extra_args: jammy-yoga
+- job:
     name: impish-xena
     description: Run a functional test against impish-xena
     parent: func-target


### PR DESCRIPTION
Add the jammy-yoga target for running tests with OpenStack Yoga on
Ubuntu 22.04 Jammy Jellyfish.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>