### PR TITLE
Run tox-py39 on focal-medium

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -89,8 +89,8 @@
 
     nodeset:
       nodes:
-        - name: impish-medium
-          label: impish-medium
+        - name: focal-medium
+          label: focal-medium
     vars:
       tox_envlist: py39
       python_version: 3.9


### PR DESCRIPTION
While running py39 on impish is preferred, we can't do that until
the [1] is available in our installed version of zuul. For now,
run py39 on focal.

https://opendev.org/zuul/zuul/commit/873028e309b0d0bae65c667e997939302d1be5a5