### PR TITLE
Add pre-flight check of DNS connectivity

### DIFF
--- a/roles/setup-networking-env/tasks/main.yaml
+++ b/roles/setup-networking-env/tasks/main.yaml
@@ -17,3 +17,7 @@
   shell: set -o pipefail && env | grep -v OS_
   args:
     executable: /bin/bash
+- name: check dns
+  shell: resolvectl; resolvectl query caipora.serverstack; resolvectl query api.jujucharms.com; host caipora.serverstack 10.245.160.2; host api.jujucharms.com 10.245.160.2; host api.jujucharms.com 10.245.160.1
+  args:
+    executable: /bin/bash


### PR DESCRIPTION
While investigating an issue where test jobs bomb out early due to
DNS resolution apparently not working, do a pre-flight check where
we attempt to resolve both names for which our DNS server has
authority and names that need remote lookup.