### PR TITLE
Temporarilly set juju model-default userdata

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -56,3 +56,16 @@
           --model-default=/tmp/charm-test-infra/juju-configs/model-default-serverstack.yaml \
           --config=/tmp/charm-test-infra/juju-configs/controller-default.yaml \
           {{ serverstack_cloud.region_name }}/{{ serverstack_cloud.region_name }}
+    - name: 'Configure cloudinit-userdata model-default'
+      shell:
+        cmd: |
+          cat > /tmp/cloudinit-userdata.yaml << EOF
+          cloudinit-userdata: |
+            preruncmd:
+              - sed -i "/^ExecStart.*systemd-resolved/a Environment=SYSTEMD_LOG_LEVEL=debug" /lib/systemd/system/systemd-resolved.service
+              - systemctl daemon-reload
+              - systemctl restart systemd-resolved
+          EOF
+          /snap/bin/juju model-default /tmp/cloudinit-userdata.yaml
+      args:
+        executable: /bin/bash

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ deps =
      # keep this in sync with what Zuul uses so we don't allow though
      # things from a later ansible that would actually fail in
      # production.
+     #
+     # https://github.com/ansible-community/ansible-lint/issues/1795
+     rich>=9.5.1,<11.0.0
      ansible>=2.8,<=2.9
      ansible-lint>=4.2.0,<5
      hacking>=2.0.0,<2.1.0


### PR DESCRIPTION
To help debug an intermittent and not reproducible issue with DNS
resolution seen in gate, have juju add cloud-init userdata that
enables debug logging for systemd-resolved.

Note that the juju model-config key `cloudinit-userdata` must be
fed in through a file and cannot be set on command line nor fed
in through the Zaza model settings environment variables.