### PR TITLE
Switch testing to use Juju 2.9/stable

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -16,7 +16,7 @@
       snap:
         name: juju
         classic: yes
-        channel: 2.8/stable
+        channel: 2.9/stable
     - name: Install libpq-dev
       become: true
       apt:

--- a/playbooks/new-tenant-juju/pre.yaml
+++ b/playbooks/new-tenant-juju/pre.yaml
@@ -95,7 +95,7 @@
       snap:
         name: juju
         classic: yes
-        channel: 2.8/stable
+        channel: 2.9/stable
     - name: Install libpq-dev
       become: true
       apt:


### PR DESCRIPTION
This patch is to switch juju to use 2.9/stable.  This is necessary as
part of the switch to charmhub.