### PR TITLE
Print more information about installed software

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -18,9 +18,16 @@
   become: true
   snap:
     name: lxd
-- name: Print installed snaps
-  when: needs_charm_build and build_type == "charmcraft"
-  command: /usr/bin/snap list
+- name: Print information about installed software
+  args:
+    executable: /bin/bash
+  shell: |
+    set -x
+    echo "build_type: {{ build_type }}"
+    snap list
+    dpkg --get-selections
+    which lxc
+    which lxd
 
 # Improvements: use the built charm tarball artifact that's sent to Zuul for
 # downloading rather than just knowing the path and using that.


### PR DESCRIPTION
Currently charmcraft seems to pick an outdated lxc
client. charmcraft issues the following command

    lxc --project charmcraft list local: --format=yaml

which is correct for me locally with lxd 4.22 but
fails on zOSCI at the moment.