### PR TITLE
Purge lxd-client package

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -13,12 +13,15 @@
   snap:
     name: charmcraft
     classic: yes
-- name: Purge lxd apt package
+- name: Purge lxd apt packages
   become: true
   apt:
-    name: lxd
+    name: "{{ item }}"
     state: absent
     purge: yes
+  loop:
+    - lxd
+    - lxd-client
 - name: Install lxd snap
   become: true
   snap:


### PR DESCRIPTION
On Xenial lxd-client ships /usr/bin/lxc but we want
charmcraft to pick up /snap/bin/lxc instead.