### PR TITLE
Initialize lxd

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -26,6 +26,8 @@
   become: true
   snap:
     name: lxd
+- name: Initialize lxd
+  command: lxd init --auto
 - name: Print information about installed software
   args:
     executable: /bin/bash


### PR DESCRIPTION
Without this charmcraft fails with

    LXD has not been properly initialized.
    Consider executing 'lxd init --auto' to initialize LXD.