### PR TITLE
Add templates for charm-unit-jobs-py*

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -126,6 +126,51 @@
         - tox-py37
         - tox-py38
 - project-template:
+    name: charm-unit-jobs-py35
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py35
+- project-template:
+    name: charm-unit-jobs-py36
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py36
+- project-template:
+    name: charm-unit-jobs-py37
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py37
+- project-template:
+    name: charm-unit-jobs-py38
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py38
+- project-template:
+    name: charm-unit-jobs-py39
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        - tox-py39
+- project-template:
     name: charm-yoga-unit-jobs
     description: |
       The default set of unit tests and lint checks for the OpenStack Charms


### PR DESCRIPTION
These are specific unit jobs (e.g. pep8 + py*) that are targetted at a
single python version.  This is so that a charm only needs to test on
the python version for the Ubuntu version that it is going to run on.