### PR TITLE
Remove hirsute from project templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ run the following unit test type jobs:
 and these functional jobs:
 
 ```
-- hirsute-wallaby
 - focal-wallaby
 - focal-victoria
 - focal-ussuri-ec

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -48,7 +48,6 @@
       The default set of functional test jobs for the OpenStack Charms
     check:
       jobs:
-        - hirsute-wallaby
         - focal-wallaby
         - focal-victoria
         - focal-ussuri
@@ -82,7 +81,6 @@
       The default set of wallaby functional test jobs for the OpenStack Charms
     check:
       jobs:
-        - hirsute-wallaby
         - focal-wallaby
 - project-template:
     name: charm-victoria-functional-jobs


### PR DESCRIPTION
Ubuntu 21.04, Hirsute Hippo, went EOL on Jan 20, 2022. This removes the
hirsute targets from the project-templates.yaml.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>