### PR TITLE
Stop func-target-pre-jobs from running until charm-build is run

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -311,6 +311,8 @@
     parent: func-target
     dependencies:
       - osci-lint
+      - name: charm-build
+        soft: true
 
 - job:
     name: bionic


### PR DESCRIPTION
This (in the new-world of charmhub migration) will stop template jobs
from running func-target until the charm-build is done.