### PR TITLE
Make charm-build a hard dependency of func-target-pre-jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -311,8 +311,7 @@
     parent: func-target
     dependencies:
       - osci-lint
-      - name: charm-build
-        soft: true
+      - charm-build
 
 - job:
     name: bionic


### PR DESCRIPTION
This is to ensure that charm-build really does run before the
func-target jobs.  For classic charms this should be a no-op and not
affect those jobs.