### PR TITLE
Debug early tox failures

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -275,6 +275,9 @@
         TEST_TRILIO_LICENSE: /tmp/tvault-license.lic
         TEST_MODEL_CONSTRAINTS: "cores=2"
       tox_envlist: func-target
+      # The first two -v's go to tox itself, and the three last ones are
+      # passed on to pip
+      tox_extra_args: -vvvvv
     secrets:
       - serverstack_cloud
       - purestorage_api_token


### PR DESCRIPTION
As recorded in #154 we have an intermittent failure at the very
beginning of a tox run which we don't have any visibility into.

Increase verbosity so that we get a chance to catch what's going
on.