### PR TITLE
Increase charm build timeout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -130,6 +130,7 @@
 - job:
     name: charm-build
     description: Build a source charm into a deployable charm
+    timeout: 3600
     parent: tox
     provides: charm
     run: playbooks/charm/build.yaml


### PR DESCRIPTION
Octavia takes a long time build and recently timed out in gate
*1 . Taking longer than 30mins to build a charm seems
excessive but thats where we are.

*1 https://openstack-ci-reports.ubuntu.com/artifacts/6ea/826711/8/check/charm-build/6ea5484/job-output.txt