### PR TITLE
Pin LXD to 4.22/stable due to recent breakage

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -26,6 +26,7 @@
   become: true
   snap:
     name: lxd
+    channel: 4.22/stable
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software


### PR DESCRIPTION
... between LXD and Charmcraft over device naming.