### PR TITLE
Add more placeholder templates for the charmhub migration

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -35,6 +35,14 @@
     description: |
       placeholder
 - project-template:
+    name: openstack-python3-wallaby-jobs
+    description: |
+      placeholder
+- project-template:
+    name: openstack-python3-victoria-jobs
+    description: |
+      placeholder
+- project-template:
     name: openstack-python3-ussuri-jobs
     description: |
       placeholder


### PR DESCRIPTION
This is to allow the .zuul.conf to reference the long lived
python3 jobs.