### PR TITLE
Remove unattended-upgrades package

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -3,6 +3,7 @@
     - add-build-sshkey
     - prepare-workspace
     - apt
+    - remove-unattended-upgrades
     # This role ensures basic connectivity and produces some
     # helpful information in zuul-info/
     - validate-host

--- a/roles/remove-unattended-upgrades/tasks/main.yaml
+++ b/roles/remove-unattended-upgrades/tasks/main.yaml
@@ -1,0 +1,15 @@
+# apt supports lock_timeout from 2.12 (impish onwards) until then manually
+# check for the lock.
+- name: Wait for apt lock
+  command: /usr/bin/lsof /var/lib/dpkg/lock-frontend
+  retries: 30
+  delay: 10
+  register: result
+  until: result.rc == 1
+  failed_when:
+    - result.rc == 0
+- name: Remove unattended-upgrades
+  apt:
+    name: unattended-upgrades
+    state: absent
+


### PR DESCRIPTION
Remove unattended-upgrades package to stop apt lock clashes

At the start of a run wait for the apt lock to be clear and then remove
the `unattended-upgrades` packages. The hope is that this will stop package
installs failing later on because they cannot get an apt lock. There are other
approaches to this problem that I did consider but had to rule out.

1) zuul-jobs uses the `package` ansible module so set a `lock_timeout`
module_default so that each package install will wait for a lock. This
only works for yum and dnf atm
2) Remove unattended-upgrades package and instead of manually checking
 for a lock use `lock_timeout` https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-lock_timeout option to apt. This only works with ansilbe on Impish or later

This change was manually tests as best as I could like this:

```
root@juju-32f784-20220317162215-0:~/ansible# find . -type f
./playbooks/base/pre.yaml
./playbooks/base/roles/remove-unattended-upgrades/tasks/main.yaml
./hosts
root@juju-32f784-20220317162215-0:~/ansible# cat ./playbooks/base/pre.yaml
- hosts: all
  roles:
    - remove-unattended-upgrades

root@juju-32f784-20220317162215-0:~/ansible# cat ./playbooks/base/roles/remove-unattended-upgrades/tasks/main.yaml
# apt supports lock_timeout from 2.12 (impish onwards) until then manually
# check for the lock.
- name: Wait for apt lock
  command: /usr/bin/lsof /var/lib/dpkg/lock-frontend
  retries: 30
  delay: 10
  register: result
  until: result.rc == 1
  failed_when:
    - result.rc == 0
- name: Remove unattended-upgrades
  apt:
    name: unattended-upgrades
    state: absent
```

Running when target has `unattended-upgrades` installed and no lock present:

```
root@juju-32f784-20220317162215-0:~/ansible# ansible-playbook -i hosts ./playbooks/base/pre.yaml

PLAY [all] **************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************************************************************************************************************************
ok: [172.20.0.168]

TASK [remove-unattended-upgrades : Wait for apt lock] *******************************************************************************************************************************************************************************************************************************
changed: [172.20.0.168]

TASK [remove-unattended-upgrades : Remove unattended-upgrades] **********************************************************************************************************************************************************************************************************************
changed: [172.20.0.168]

PLAY RECAP **************************************************************************************************************************************************************************************************************************************************************************
172.20.0.168               : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

root@juju-32f784-20220317162215-0:~/ansible# ssh 172.20.0.168 "dpkg -l unattended-upgrades"
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                Version      Architecture Description
+++-===================-============-============-===========================================
rc  unattended-upgrades 2.3ubuntu0.1 all          automatic installation of security upgrades
```

Running when target does not have `unattended-upgrades` installed and no lock present:

```
root@juju-32f784-20220317162215-0:~/ansible# ssh 172.20.0.168 "dpkg -l unattended-upgrades"
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                Version      Architecture Description
+++-===================-============-============-===========================================
rc  unattended-upgrades 2.3ubuntu0.1 all          automatic installation of security upgrades
root@juju-32f784-20220317162215-0:~/ansible# 
root@juju-32f784-20220317162215-0:~/ansible# 
root@juju-32f784-20220317162215-0:~/ansible# 
root@juju-32f784-20220317162215-0:~/ansible# ansible-playbook -i hosts ./playbooks/base/pre.yaml

PLAY [all] **************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************************************************************************************************************************
ok: [172.20.0.168]

TASK [remove-unattended-upgrades : Wait for apt lock] *******************************************************************************************************************************************************************************************************************************
changed: [172.20.0.168]

TASK [remove-unattended-upgrades : Remove unattended-upgrades] **********************************************************************************************************************************************************************************************************************
ok: [172.20.0.168]

PLAY RECAP **************************************************************************************************************************************************************************************************************************************************************************
172.20.0.168               : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

root@juju-32f784-20220317162215-0:~/ansible# ssh 172.20.0.168 "dpkg -l unattended-upgrades"
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                Version      Architecture Description
+++-===================-============-============-===========================================
rc  unattended-upgrades 2.3ubuntu0.1 all          automatic installation of security upgrades
root@juju-32f784-20220317162215-0:~/ansible# 
```

Running when `unattended-upgrades` installed and lock present then releasing lock:

```
root@juju-32f784-20220317162215-0:~/ansible# ansible-playbook -i hosts ./playbooks/base/pre.yaml

PLAY [all] **************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************************************************************************************************************************
ok: [172.20.0.168]

TASK [remove-unattended-upgrades : Wait for apt lock] *******************************************************************************************************************************************************************************************************************************
FAILED - RETRYING: Wait for apt lock (30 retries left).
FAILED - RETRYING: Wait for apt lock (29 retries left).
FAILED - RETRYING: Wait for apt lock (28 retries left).
FAILED - RETRYING: Wait for apt lock (27 retries left).
FAILED - RETRYING: Wait for apt lock (26 retries left).
FAILED - RETRYING: Wait for apt lock (25 retries left).
FAILED - RETRYING: Wait for apt lock (24 retries left).
changed: [172.20.0.168]

TASK [remove-unattended-upgrades : Remove unattended-upgrades] **********************************************************************************************************************************************************************************************************************
changed: [172.20.0.168]

PLAY RECAP **************************************************************************************************************************************************************************************************************************************************************************
172.20.0.168               : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

