### PR TITLE
Use sudo in apt lock check

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -2,7 +2,7 @@
   roles:
     - add-build-sshkey
     - prepare-workspace
-    - apt
+    - prepare-package-environment
     # This role ensures basic connectivity and produces some
     # helpful information in zuul-info/
     - validate-host

--- a/roles/prepare-package-environment/tasks/main.yaml
+++ b/roles/prepare-package-environment/tasks/main.yaml
@@ -2,6 +2,7 @@
 # until then manually check for the lock.
 - name: Wait for apt lock
   command: /usr/bin/lsof /var/lib/dpkg/lock-frontend
+  become: yes
   retries: 30
   delay: 10
   register: result
@@ -12,6 +13,7 @@
 # installed.
 # WARNING: This is a throw-away CI environment, do not do this at home
 - name: Remove unattended-upgrades
+  become: yes
   apt:
     name: unattended-upgrades
     state: absent


### PR DESCRIPTION
The previous test of prepare-package-environment was done as root.
However running as non-root user causes the apt lock check to fail.
This change re-enables prepare-package-environment and switches
the lock check to run as root.