### PR TITLE
Bump LXD channel

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -26,7 +26,7 @@
   become: true
   snap:
     name: lxd
-    channel: 4.22/stable
+    channel: latest/stable
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software


### PR DESCRIPTION
Looks like the 4.22 channel has gone so bump to 4.23.


```
channels:
  latest/stable:    4.24-c92c0b2  2022-03-25 (22754) 82MB -
  latest/candidate: 4.24-c92c0b2  2022-03-24 (22754) 82MB -
  latest/beta:      4.23          2022-03-12 (22652) 82MB -
  latest/edge:      git-03a4e69   2022-03-25 (22768) 82MB -
  4.24/stable:      4.24          2022-03-22 (22710) 82MB -
  4.24/candidate:   4.24          2022-03-22 (22710) 82MB -
  4.24/beta:        ↑                                     
  4.24/edge:        ↑                                     
  4.23/stable:      4.23          2022-03-13 (22652) 82MB -
  4.23/candidate:   4.23          2022-03-10 (22633) 82MB -
  4.23/beta:        ↑                                     
  4.23/edge:        ↑                                     
  4.0/stable:       4.0.9         2022-02-25 (22526) 71MB -
  4.0/candidate:    4.0.9-8e2046b 2022-03-24 (22753) 71MB -
  4.0/beta:         ↑                                     
  4.0/edge:         git-407205d   2022-03-24 (22748) 71MB -
  3.0/stable:       3.0.4         2019-10-10 (11348) 55MB -
  3.0/candidate:    3.0.4         2019-10-10 (11348) 55MB -
  3.0/beta:         ↑                                     
  3.0/edge:         git-81b81b9   2019-10-10 (11362) 55MB -
installed:          4.0.9                    (22526) 71MB -
```