### PR TITLE
Jammy's python is 3.10 so switch jammy-yoga dependency

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -408,7 +408,7 @@
     description: Run a functional test against jammy-yoga
     parent: func-target-pre-jobs
     dependencies:
-      - tox-py39
+      - tox-py310
       - osci-lint
       - charm-build
     vars:


### PR DESCRIPTION
Switch the job to depend on from py39 to py310 to align with
jammy's (recent) default of Python3.10