### PR TITLE
Quote 3.10 for unit jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -141,7 +141,7 @@
           label: focal-medium
     vars:
       tox_envlist: py310
-      python_version: 3.10
+      python_version: '3.10'
 
 - job:
     name: charm-build


### PR DESCRIPTION
Without quoting 3.10, YAML evaluates it as `3.1` which isn't desired