### PR TITLE
Jammy ships with Python 3.10 as the default Py3 so model dependencies…

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -358,7 +358,8 @@
     description: Run a functional test against jammy
     parent: func-target-pre-jobs
     dependencies:
-      # - tox-py310 # Disable until OSCI has jammy images
+      - name: tox-py310
+        soft: true
       - osci-lint
       - charm-build
     vars:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -358,7 +358,7 @@
     description: Run a functional test against jammy
     parent: func-target-pre-jobs
     dependencies:
-      - tox-py10
+      # - tox-py310 # Disable until OSCI has jammy images
       - osci-lint
       - charm-build
     vars:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -358,7 +358,7 @@
     description: Run a functional test against jammy
     parent: func-target-pre-jobs
     dependencies:
-      - tox-py39
+      - tox-py10
       - osci-lint
       - charm-build
     vars:


### PR DESCRIPTION
… as such.