### PR TITLE
Retry LXD snap installation.

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -27,6 +27,10 @@
   snap:
     name: lxd
     channel: latest/stable
+  retries: 5
+  delay: 5
+  register: result
+  until: result.rc == 0
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software


### PR DESCRIPTION
This change add retries to lxd snap installation to make this task more
robust and to overcome hiccups found in the Snap store detected by the
CI jobs.

https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met