### PR TITLE
Revert "Retry LXD snap installation."

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -27,10 +27,6 @@
   snap:
     name: lxd
     channel: latest/stable
-  retries: 5
-  delay: 5
-  register: result
-  until: result.rc == 0
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software


### PR DESCRIPTION
The `until` check seems to be wrong resulting in jobs failing with:

"msg": "The conditional check 'result.rc == 0' failed. The error was: error while evaluating conditional (result.rc == 0): 'dict object' has no attribute 'rc'"

This reverts commit e25b200bf82884d973eae476c18718da30d2b395.