### PR TITLE
Pin charmcraft to 1.5/stable

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -13,6 +13,7 @@
   snap:
     name: charmcraft
     classic: yes
+    channel: "1.5/stable"
 - name: Purge lxd apt packages
   become: true
   apt:


### PR DESCRIPTION
charmcraft 1.6 renamed the environment variable from CHARMCRAFT_STAGE to
CRAFT_STAGE breaking charms building.

https://github.com/canonical/craft-parts/commit/6c18447497897794dc9ea86f164fb21c035f12d1