### PR TITLE
Increase setup attempts from 2 to 4

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -5,7 +5,7 @@
     roles:
       - zuul: zuul/zuul-jobs
     timeout: 1800
-    attempts: 2
+    attempts: 4
     nodeset:
       nodes:
         - name: focal-medium


### PR DESCRIPTION
Zuul will retry the pre-test steps up to $attempts times, this change
increases how tolerant we are to infrastructural issues that can cause
a job to fail early