### PR TITLE
Fix intermittent failures due to dpkg-lock

### DIFF
--- a/roles/prepare-package-environment/tasks/main.yaml
+++ b/roles/prepare-package-environment/tasks/main.yaml
@@ -1,3 +1,15 @@
+# Remove unattended-upgrades to stop clashes when other packages need to be
+# installed.
+# WARNING: This is a throw-away CI environment, do not do this at home
+#
+# Removing the package does not stop the service, so stop it first and then
+# check for the dpkg-lock in case the daemon kicks off a job while we're
+# performing this task.
+- name: Stop unattended-upgrades service
+  become: yes
+  systemd:
+    name: unattended-upgrades
+    state: stopped
 # The ansible apt module supports lock_timeout from 2.12 (impish onwards)
 # until then manually check for the lock.
 - name: Wait for apt lock
@@ -9,9 +21,6 @@
   until: result.rc == 1
   failed_when:
     - result.rc == 0
-# Remove unattended-upgrades to stop clashes when other packages need to be
-# installed.
-# WARNING: This is a throw-away CI environment, do not do this at home
 - name: Remove unattended-upgrades
   become: yes
   apt:


### PR DESCRIPTION
Extend the apt lock timeout.

Fixes: #195