### PR TITLE
Also get files with strict permissions in crashdump

### DIFF
--- a/playbooks/juju/post.yaml
+++ b/playbooks/juju/post.yaml
@@ -11,7 +11,10 @@
       shell: |
         set -o pipefail
         for model in $(juju models | grep zaza- | awk '{gsub(/\*?/,""); print $1}'); do
-          juju-crashdump -o "{{ zuul.project.src_dir }}/log" -m $model \
+          juju-crashdump \
+            -o "{{ zuul.project.src_dir }}/log" \
+            -m $model \
+            --as-root \
             /etc/apache2 \
             /etc/haproxy \
             /etc/openvswitch \


### PR DESCRIPTION
This is a CI environment with no state secrets, the files could
contain valuable information for triaging a problem.

Incidentally this also works around a bug in juju crashdump which
currently renders the crashdumps empty.