### PR TITLE
Add a focal-ussuri specific functional job template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -111,6 +111,14 @@
         - focal-ussuri
         - bionic-ussuri
 - project-template:
+    name: charm-focal-ussuri-functional-jobs
+    description: |
+      The default set of ussuri functional test jobs (focal only) for the
+      OpenStack Charms
+    check:
+      jobs:
+        - focal-ussuri
+- project-template:
     name: charm-train-functional-jobs
     description: |
       The default set of stein functional test jobs for the OpenStack Charms


### PR DESCRIPTION
This is needed for the stable/victoria branch as it needs to test
the focal-ussuri job, but doesn't need to test the bionic-ussuri job,
nor be dependent on tox-py36.