### PR TITLE
Reducing concurrency of functional tests to 15

### DIFF
--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,3 +1,3 @@
 - semaphore:
     name: functional-test
-    max: 18
+    max: 15


### PR DESCRIPTION
The cloud where zosci runs lost a node due to hardware failures, this
node represents 6% of the capacity of the environment to run CI jobs.