### PR TITLE
Capture journalctl.

### DIFF
--- a/playbooks/juju/post.yaml
+++ b/playbooks/juju/post.yaml
@@ -15,6 +15,7 @@
             -o "{{ zuul.project.src_dir }}/log" \
             -m $model \
             --as-root \
+            -j '*' \
             /etc/apache2 \
             /etc/haproxy \
             /etc/openvswitch \


### PR DESCRIPTION
The flag `-j '*'` is translated to `journalctl -u '*'` which makes
journalctl to match the logs for all the units of the system in a single
stream. juju-crashdump will produce a single file named '*.log' as
shown here:

[...]/2/baremetal/journalctl/
[...]/2/baremetal/journalctl/*.log