### PR TITLE
Add kinetic-zed and jammy-zed

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -405,6 +405,17 @@
     vars:
       tox_extra_args: bionic-queens
 - job:
+    name: kinetic-zed
+    description: Run a functional test against kinetic-zed
+    parent: func-target-pre-jobs
+    dependencies:
+      - name: tox-py310
+        soft: true
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: kinetic-zed
+- job:
     name: jammy-yoga
     description: Run a functional test against jammy-yoga
     parent: func-target-pre-jobs
@@ -445,6 +456,16 @@
       - charm-build
     vars:
       tox_extra_args: groovy-victoria
+- job:
+    name: jammy-zed
+    description: Run a functional test against jammy-zed
+    parent: func-target-pre-jobs
+    dependencies:
+      - tox-py310
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: jammy-zed
 - job:
     name: focal-yoga
     description: Run a functional test against focal-yoga

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -410,7 +410,6 @@
     parent: func-target-pre-jobs
     dependencies:
       - name: tox-py310
-        soft: true
       - osci-lint
       - charm-build
     vars:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -27,6 +27,10 @@
     description: |
       placeholder
 - project-template:
+    name: openstack-python3-charm-zed-jobs
+    description: |
+      placeholder
+- project-template:
     name: openstack-python3-charm-yoga-jobs
     description: |
       placeholder
@@ -72,6 +76,16 @@
         - bionic-stein
         - bionic-queens
         - xenial-mitaka
+- project-template:
+    name: charm-zed-functional-jobs
+    description: |
+      The default set of zed functional test jobs for the OpenStack Charms
+    check:
+      jobs:
+        - kinetic-zed:
+            voting: false
+        - jammy-zed:
+            voting: false
 - project-template:
     name: charm-yoga-functional-jobs
     description: |


### PR DESCRIPTION
Add the kinetic-zed and jammy-zed targets for running tests
on 22.10 and 22.04 with the Ubuntu Cloud Archive.