### PR TITLE
More apt lock checking

### DIFF
--- a/roles/prepare-package-environment/tasks/main.yaml
+++ b/roles/prepare-package-environment/tasks/main.yaml
@@ -26,10 +26,28 @@
   apt:
     name: unattended-upgrades
     state: absent
+- name: Wait for apt lock
+  command: /usr/bin/lsof /var/lib/dpkg/lock-frontend
+  become: yes
+  retries: 30
+  delay: 10
+  register: result
+  until: result.rc == 1
+  failed_when:
+    - result.rc == 0
 - name: "apt-get update"
   become: yes
   apt:
     update_cache: yes
+- name: Wait for apt lock
+  command: /usr/bin/lsof /var/lib/dpkg/lock-frontend
+  become: yes
+  retries: 30
+  delay: 10
+  register: result
+  until: result.rc == 1
+  failed_when:
+    - result.rc == 0
 - name: "apt install dist-upgrade"
   become: yes
   apt:


### PR DESCRIPTION
CI is still sometimes hitting failures when an apt lock
is still present *1 . This adds additional apt lock checks prior to
apt calls.

http://10.245.164.110/t/openstack/stream/e63240075f0f430baac9a5fae10ee77b?logfile=console.log