### PR TITLE
Retry on failure when installing a snap.

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -10,6 +10,10 @@
       snap:
         name: juju-crashdump
         classic: yes
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     # Setup Juju
     - name: 'install juju'
       become: true
@@ -17,6 +21,10 @@
         name: juju
         classic: yes
         channel: 2.9/stable
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     - name: Install libpq-dev
       become: true
       apt:

--- a/playbooks/new-tenant-juju/pre.yaml
+++ b/playbooks/new-tenant-juju/pre.yaml
@@ -10,14 +10,26 @@
       snap:
         name: juju-crashdump
         classic: yes
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     - name: 'install openstackclients'
       become: true
       snap:
         name: openstackclients
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     - name: 'install jq'
       become: true
       snap:
         name: jq
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     - name: 'install ospurge'
       become: true
       pip:
@@ -96,6 +108,10 @@
         name: juju
         classic: yes
         channel: 2.9/stable
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
     - name: Install libpq-dev
       become: true
       apt:

--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -14,6 +14,10 @@
     name: charmcraft
     classic: yes
     channel: "1.5/stable"
+  register: result
+  until: result is not failed
+  retries: 10
+  delay: 10
 - name: Purge lxd apt packages
   become: true
   apt:
@@ -28,6 +32,10 @@
   snap:
     name: lxd
     channel: latest/stable
+  register: result
+  until: result is not failed
+  retries: 10
+  delay: 10
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software


### PR DESCRIPTION
This change adds 10 retries with a 10 seconds delay between retries to
every task that installs a snap to make more robust this process more
robust and resilent when there are transient issues with the snapstore
or the network connectivity.