### PR TITLE
Always include phased updates.

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -69,6 +69,13 @@
         cmd: |
           cat > /tmp/cloudinit-userdata.yaml << EOF
           cloudinit-userdata: |
+            apt:
+              conf: |
+                APT {
+                  Get {
+                    Always-Include-Phased-Updates 'true';
+                  }
+                }
             preruncmd:
               - sed -i "/^ExecStart.*systemd-resolved/a Environment=SYSTEMD_LOG_LEVEL=debug" /lib/systemd/system/systemd-resolved.service
               - systemctl daemon-reload


### PR DESCRIPTION
Include a cloud-init configuration chunk to setup machines to always
include phased updates when installing packages via apt, this ensures
that the CI is an early user of packages that were pushed into the
-updates pocket and are still being rolled up.

A report of what packages are being phased at any given time with its
current percentage progress can be found
https://people.canonical.com/~ubuntu-archive/phased-updates.html

For more details see
https://discourse.ubuntu.com/t/phased-updates-in-apt-in-21-04/20345