### PR TITLE
debug: Increase max job timeout

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -4,7 +4,7 @@
     # report-build-page is disabled so that we don't send links
     # to this Zuul to Gerrit when reporting job success/failure
     report-build-page: false
-    max-job-timeout: 28800
+    max-job-timeout: 86400
     source:
       github-git:
         config-projects:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -173,7 +173,7 @@
     # abstract job; use as parent for other jobs
     abstract: true
     parent: configure-juju
-    timeout: 10800
+    timeout: 86400
     attempts: 4
     semaphore: functional-test
     # as an alternate to semaphores, or along side them, we could define


### PR DESCRIPTION
Allow debugging CI infrastructure issues.

The change proposed in openstack-charmers/zaza#524 pauses a job
on install hook failures.

This change follows along to allow humans to look at any instances
stuck in this state.