### PR TITLE
Add netapp_pool_name_search_pattern

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -270,6 +270,7 @@
         TEST_NETAPP_SAN_USERNAME: vsadmin
         TEST_NETAPP_SAN_PASSWORD: "{{ netapp_vsadmin_password.value }}"
         TEST_NETAPP_ROOT_VOL_AGGR_NAME: openstack
+        TEST_NETAPP_POOL_NAME_SEARCH_PATTERN: zaza
         TEST_ARISTA_IMAGE_REMOTE: 'http://10.245.161.162/swift/v1/images/arista-cvx-virt-test.qcow2'
         TEST_IRONIC_DEPLOY_INITRD: 'http://10.245.161.162/swift/v1/images/ironic-python-agent.initramfs'
         TEST_IRONIC_DEPLOY_VMLINUZ: 'http://10.245.161.162/swift/v1/images/ironic-python-agent.kernel'


### PR DESCRIPTION
Add netapp_pool_name_search_pattern so the functional tests can
find the pool in the netapp server.

Closes-Bug: #1982114