### PR TITLE
Allow osci.yaml to control the charmcraft build version

### DIFF
--- a/roles/charm-build/defaults/main.yaml
+++ b/roles/charm-build/defaults/main.yaml
@@ -1,3 +1,4 @@
 needs_charm_build: false
 charm_build_name: null
 build_type: reactive
+charmcraft_channel: "1.5/stable"

--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -13,7 +13,7 @@
   snap:
     name: charmcraft
     classic: yes
-    channel: "1.5/stable"
+    channel: "{{ charmcraft_channel }}"
   register: result
   until: result is not failed
   retries: 10


### PR DESCRIPTION
Allow the osci.yaml to include a var `charmcraft_channel` that can be
optionally used to override the default charmcraft channel that the snap
installs from.  This is to allow different branches to control which
version of charmcraft that they should use.  The default version is
fixed at "1.5/stable" which is used for all the backport branches.