### PR TITLE
Add support to publish charms to charmhub

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -45,6 +45,8 @@
           - openstack/charm-cinder-backup: *default-project
           - openstack/charm-cinder-backup-swift-proxy: *default-project
           - openstack/charm-cinder-ceph: *default-project
+          - openstack/charm-cinder-ceph-k8s: *default-project
+          - openstack/charm-cinder-k8s: *default-project
           - openstack/charm-cinder-lvm: *default-project
           - openstack/charm-cinder-netapp: *default-project
           - openstack/charm-cinder-nimblestorage: *default-project
@@ -54,13 +56,16 @@
           - openstack/charm-designate: *default-project
           - openstack/charm-designate-bind: *default-project
           - openstack/charm-glance: *default-project
+          - openstack/charm-glance-k8s: *default-project
           - openstack/charm-glance-simplestreams-sync: *default-project
           - openstack/charm-gnocchi: *default-project
           - openstack/charm-hacluster: *default-project
           - openstack/charm-heat: *default-project
+          - openstack/charm-horizon-k8s: *default-project
           - openstack/charm-ironic-api: *default-project
           - openstack/charm-ironic-conductor: *default-project
           - openstack/charm-keystone: *default-project
+          - openstack/charm-keystone-k8s: *default-project
           - openstack/charm-keystone-kerberos: *default-project
           - openstack/charm-keystone-ldap: *default-project
           - openstack/charm-keystone-saml-mellon: *default-project
@@ -82,11 +87,13 @@
           - openstack/charm-neutron-api-plugin-ovn: *default-project
           - openstack/charm-neutron-dynamic-routing: *default-project
           - openstack/charm-neutron-gateway: *default-project
+          - openstack/charm-neutron-k8s: *default-project
           - openstack/charm-neutron-openvswitch: *default-project
           - openstack/charm-nova-cell-controller: *default-project
           - openstack/charm-nova-cloud-controller: *default-project
           - openstack/charm-nova-compute: *default-project
           - openstack/charm-nova-compute-nvidia-vgpu: *default-project
+          - openstack/charm-nova-k8s: *default-project
           - openstack/charm-octavia: *default-project
           - openstack/charm-octavia-dashboard: *default-project
           - openstack/charm-octavia-diskimage-retrofit: *default-project
@@ -95,6 +102,7 @@
           - openstack/charm-pacemaker-remote: *default-project
           - openstack/charm-percona-cluster: *default-project
           - openstack/charm-placement: *default-project
+          - openstack/charm-placement-k8s: *default-project
           - openstack/charm-rabbitmq-server: *default-project
           - openstack/charm-swift-proxy: *default-project
           - openstack/charm-swift-storage: *default-project
@@ -105,6 +113,8 @@
           - openstack/charm-trilio-wlm: *default-project
           - openstack/charm-vault: *default-project
           - x/charm-ovn-central: *default-project
+          - x/charm-ovn-central-k8s: *default-project
           - x/charm-ovn-chassis: *default-project
           - x/charm-ovn-dedicated-chassis: *default-project
+          - x/charm-ovn-relay-k8s: *default-project
           - x/microstack: *default-project

--- a/playbooks/charm/publish.yaml
+++ b/playbooks/charm/publish.yaml
@@ -1,0 +1,6 @@
+- hosts: all
+  vars_files:
+    - ../../site-vars.yaml
+  roles:
+    - charm-build
+    - publish-charm

--- a/roles/publish-charm/defaults/main.yaml
+++ b/roles/publish-charm/defaults/main.yaml
@@ -1,0 +1,6 @@
+needs_charm_build: false
+charm_build_name: null
+build_type: charmcraft
+publish_charm: false
+charmcraft_channel: 2.0/stable
+publish_channel: latest/edge

--- a/roles/publish-charm/tasks/main.yaml
+++ b/roles/publish-charm/tasks/main.yaml
@@ -1,0 +1,58 @@
+- name: Publish charms to charmhub
+  when: publish_charm
+  environment:
+    CHARMCRAFT_AUTH: "{{ charmhub_token.value }}"
+  block:
+    - name: Install docker
+      include_role:
+        name: ensure-docker
+    - name: Upload oci-image to charmhub
+      register: upload_oci_image_output
+      vars:
+        metadata: "{{ lookup('file', zuul.project.src_dir+'/metadata.yaml') | from_yaml }}"
+      args:
+        executable: /bin/bash
+      shell: |
+        set -x
+        image={{ item.value['upstream-source'] }}
+        # Remove docker.io/ in the OCI image so that docker pulls image
+        # from mirror if configured.
+        image=${image#"docker.io/"}
+        docker pull $image
+        digest=`docker inspect --format='\{\{.RepoDigests\}\}' $image | sed  -e "s/^\[//" -e "s/\]$//"`
+        charmcraft upload-resource {{ charm_build_name }} {{ item.key }} --image $digest
+      retries: 3
+      until: >
+        ("Revision" in upload_oci_image_output.stdout)
+      loop: "{{ lookup('ansible.builtin.dict', metadata.resources, wantlist=True) }}"
+      when: "item.value.type == 'oci-image'"
+
+    - name: Extract Resource revisions
+      set_fact:
+        resource_revision_flags: "{{ resource_revision_flags | default('') + ' --resource ' + item.item.key + ':' + (item.stdout | regex_search('Revision ([0-9]+)', '\\1', multiline=True) | first) }}"
+      with_items: "{{ upload_oci_image_output.results }}"
+
+    - name: Upload charm to charmhub
+      register: upload_charm_output
+      args:
+        chdir: "{{ zuul.project.src_dir }}"
+      command:
+        charmcraft upload --name {{ charm_build_name }} {{ charm_build_name }}.charm
+        # TODO: The above command can error out with a message that says
+        # upload with that digest already exists. This case need to be handled.
+        # More details https://github.com/canonical/charmcraft/issues/826
+      retries: 3
+      until: >
+        ("Revision" in upload_charm_output.stdout)
+
+    - name: Extract Charm revision
+      set_fact:
+        charm_revision: "{{ upload_charm_output.stdout | regex_search('Revision ([0-9]+)', '\\1', multiline=True) | first }}"
+
+    - name: Release charm
+      register: release_charm_output
+      command:
+        charmcraft release {{ charm_build_name }} --revision {{ charm_revision }} --channel {{ publish_channel }} {{ resource_revision_flags }}
+      retries: 3
+      until: >
+        ("Revision" in release_charm_output.stdout)

--- a/site-vars.yaml
+++ b/site-vars.yaml
@@ -1,0 +1,6 @@
+# Placeholder to update site specific variables
+
+# Internal docker pull-through cache/mirror registry
+zuul_site_mirror_fqdn: 10.245.167.88
+docker_insecure_registries:
+  - 10.245.167.88:8082

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -728,3 +728,18 @@
       - serverstack_admin
     vars:
       juju_snap_channel: "2.9/stable"
+
+- job:
+    name: publish-charm
+    description: Publish a charm to charmhub
+    timeout: 1200
+    parent: tox
+    provides: charm
+    run: playbooks/charm/publish.yaml
+    secrets:
+      - serverstack_cloud
+      - charmhub_token
+    nodeset:
+      nodes:
+        - name: focal-medium
+          label: focal-medium

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -110,3 +110,25 @@
       mysql:
     failure:
       mysql:
+
+- pipeline:
+    name: promote
+    description: |
+      This pipeline runs jobs that operate after each change is merged
+      in order to promote artifacts generated in the gate pipeline.
+    success-message: |
+      Build SUCCESS by Canonical OpenStack Charm CI (promote pipeline).
+    failure-message: |
+      Build FAILURE by Canonical OpenStack Charm CI (promote pipeline).
+    manager: supercedent
+    precedence: low
+    post-review: True
+    trigger:
+      gerrit:
+        - event: change-merged
+    success:
+      gerrit: {}
+      sqlreporter:
+    failure:
+      gerrit: {}
+      sqlreporter:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -254,3 +254,10 @@
         # NOTE(icey) BUT REALLY, DO NOT ENABLE THE FOLLOWING UNTIL YOU KNOW WE CAN
         # RUN A 3.10 JOB ON ZOSCI.
         #- tox-py310
+- project-template:
+    name: charm-publish-jobs
+    description: |
+      The set of publish jobs for the OpenStack Charms
+    promote:
+      jobs:
+        - publish-charm

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -132,3 +132,27 @@
         +PquwBxEjrO6g/Z/07wx2KTwPc1vPGY2oqfSG6N9CS7FruOJZzA+ZXX9KEDkN7RQ7ydTx
         PPVLln0767uKOREY3iC5lH8xncK8UpFk4UHvjGB+ILEM62O1Ie/W2fssvIhy0TIW69ixm
         yjOcJDBCHjYcqssJfraFHYHjkHP82LLoXBUs6HYPtKk63NlbVr0eI/AVTsT5eM=
+- secret:
+    name: charmhub_token
+    data:
+      value: !encrypted/pkcs1-oaep
+        - hTEGoTpz12WK9DVI+T6A2TUCub2d0JahRJBvEfr5ndF0NKE2hEbvtjRsaOwUfq6c0RRZ6
+          LNYW7+hJBrJTWd+rFqGZWLmOfCIddaJ0mVcgc61jt79dBTFDH70aMSsLuq/I+yKOV3r61
+          Si04DdAssWsfge5oPmyQSZg8P4axwkyjehk+Nz90NS2zC5BZl4wg29INOawj4At4OHUQe
+          wYWJstNi7f1zbxcPyvc5BE9fNAxpkyJM1byBfHQXlUJf6vYfeQyE07mKvIyKIJzoIpQWI
+          DimOYdhfSvNgyWhDeOjlA2m1K3hD/FpFGGNpO5lf4Rs/FHdrAmlbN9r9pMPfDL77lHd8m
+          DIqAoijQ4AGmhoJVmyqODBOO7LZ6P1X2mfd8MmgcAo/jDw/vLWkOUEOZ3WZFLdPGPEGnx
+          OlFSacDrZFG+rF7FKv6uqlDxWsXUIS4vQkAvXF+YKHwx6A7UhF+xHOU73Yz8tVxnGd3Vl
+          YBFOjEcKDVFiyo0ZxucAFPRY58dIoxJMnozjpv5YbV0bEvC9+zGpoBAOgu+5zMf/Yjdkp
+          Zfg7ss45CKefP9cWlq706jzR1fvvasDSgXRetyYaxkE9D4OwM5QpS3u/ncZOjnD7iA4h2
+          Cj24rnBNaUdh+PK2nPvMGIK1EzQMMxwdHqTFtixt1qL+Ai6/fnPXMY6DdkAt9g=
+        - lpd4u1UmvzcylFtZ+uZvjcc/WZbHxS4JmCGJazsDpg4lwFkoRKLALaVGt11vZVH5peAjl
+          78bWoS8CuAld2F4VYDbwo48h+OOCW8mdzEO4bnm+k2+tVP4jWSBSkKQG7wTwXkJM7k5Gi
+          A118p9HXIayafXPOlqMio5qH8SD4BfTPUXdqiug8NxCi+/YQrBPsTzuzXqmONsCmLp3s4
+          rmIz21QRuaqoPxH3nG2ShvpdsMhhIRALlYKi7xmwCy3h9CfUmngm/lyWqL5vC8l9g/Kgw
+          M0Gyr5Ve66hG1hVf3qGTtqLwunBfKkWVFuGxX3L5Z1OudjoAXvO8DyymIow03uDDDHSch
+          unGtruxfozgr7S/enQUs0UA6EUnowY8b4roUQ3VeHMqGv5f2uWuvDqr1N0M9nQiCIbIYT
+          RLhaPB3JAmvbGnyl9k2OutI1vgY5ZJ4lLkgubJRQgdYHnF7/PLKmdV34HQZ93f0PqKIFC
+          PdfWzk8l2FGGGc+Wpn1W599Hq8s0FS6TJqCK2gyzi4A0X2xtQetuEtzHLp+3ZX4KisH7r
+          rrZolxpeUEhBcgsAeCF0WssJU4Ai4eGggwMHna8VP6GMOqF+HI/fCUL5wDmyIC7qQ3WzB
+          CeHIIfdet0MLexR5nRtkyfUy/7IRvj2DC0biQxuSliyQkmkPDTdJTQ/cVsNHNY=


### PR DESCRIPTION
* Update project-templates, jobs, playbook, roles
to support publishing charms to charmhub
* Add promote pipeline to listen on gerrit change-merged event
* Introduce new variable publish_charm to decide
whether to publish charm or not

With this patch, the charms should set following variables
in osci.yaml
- needs_charm_build
- build_type
- charm_build_name
- charmcraft_channel
- publish_charm