### PR TITLE
Increase timeout for func-target

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -173,7 +173,7 @@
     # abstract job; use as parent for other jobs
     abstract: true
     parent: configure-juju
-    timeout: 10800
+    timeout: 14400
     attempts: 4
     semaphore: functional-test
     # as an alternate to semaphores, or along side them, we could define


### PR DESCRIPTION
Octavia functional tests are sometimes exceeding the timeout *1
even though the tests are working as designed. A recent run
looked like this:

Time	Task
35	Setting up deployment environment
50	Deployment
50	Configure
10	LBAASv2Tes
01	CharmOperationTest
45      policyd tests

This PR increases the timeout to 4 hours. This has the
downside that an executor will be tie'd up for an extra hour
if the test is stuck.

*1 https://openstack-ci-reports.ubuntu.com/artifacts/300/842207/5/check/focal-victoria-ha/300928c/job-output.txt