### PR TITLE
Add jammy-yoga to charm-zed-functional-jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -86,6 +86,7 @@
             voting: false
         - jammy-zed:
             voting: false
+        - jammy-yoga
 - project-template:
     name: charm-yoga-functional-jobs
     description: |


### PR DESCRIPTION
This allows execution of voting jammy-yoga tests without having to
run focal-yoga tests. Additionally, this allows for dropping of the
charm-yoga-functional-jobs template.