### PR TITLE
Enable workaround for bug 1987332

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -297,6 +297,9 @@
         TEST_MAX_RESOLVE_COUNT: 3
         # allow more time for deployements - 2 hours
         TEST_DEPLOY_TIMEOUT: 7200
+        # Enable workaround for bug http://pad.lv/1987332
+        # https://github.com/openstack-charmers/zaza/commit/fc268181e8da1cb4293328fa2e78082873d98697
+        TEST_ZAZA_BUG_LP1987332: "1"
       tox_envlist: func-target
     secrets:
       - serverstack_cloud


### PR DESCRIPTION
This change sets the environment variable TEST_ZAZA_BUG_LP1987332 to
enable the workaround for bug LP:# 1987332. This change can be dropped
once that gets fixed.

Related-Bug: #1987332
Related-PR: openstack-charmers/zaza#556