### PR TITLE
Enable osci.yaml/jobs to override juju channel

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -20,7 +20,7 @@
       snap:
         name: juju
         classic: yes
-        channel: 2.9/stable
+        channel: "{{ juju_snap_channel }}"
       register: result
       until: result is not failed
       retries: 10

--- a/playbooks/new-tenant-juju/pre.yaml
+++ b/playbooks/new-tenant-juju/pre.yaml
@@ -107,7 +107,7 @@
       snap:
         name: juju
         classic: yes
-        channel: 2.9/stable
+        channel: "{{ juju_snap_channel }}"
       register: result
       until: result is not failed
       retries: 10

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -166,6 +166,8 @@
     cleanup-run: playbooks/juju/cleanup.yaml
     secrets:
       - serverstack_cloud
+    vars:
+      juju_snap_channel: "2.9/stable"
 
 - job:
     name: func-target
@@ -724,3 +726,5 @@
     cleanup-run: playbooks/new-tenant-juju/cleanup.yaml
     secrets:
       - serverstack_admin
+    vars:
+      juju_snap_channel: "2.9/stable"


### PR DESCRIPTION
For a func-test style job, allow the juju version to be overridden
in the project's variables, or job variables.

e.g. from an osci.yaml

  - project:
      templates:
        - charm-unit-jobs-py36
        - charm-unit-jobs-py38
      check:
        jobs:
          - focal-yoga
      vars:
        needs_charm_build: true
        charm_build_name: hacluster
        build_type: charmcraft
        juju_snap_channel: "2.8/stable"

This would override the default (currently 2.9/stable) with
2.8/stable