### PR TITLE
Change publish-charm job timeout to 60 minutes

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -732,7 +732,7 @@
 - job:
     name: publish-charm
     description: Publish a charm to charmhub
-    timeout: 1200
+    timeout: 3600
     parent: tox
     provides: charm
     run: playbooks/charm/publish.yaml


### PR DESCRIPTION
publish-charm job includes charm-build role which took
around 20 minutes for keystone-k8s charm. The timeout
value need to be checked against all the sunbeam charms.
Setting publish-charm job timeout to 60 minutes to allow
publish-charm job to succeed for all the sunbeam charms.