### PR TITLE
Change sqlreporter to mysql

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -128,7 +128,7 @@
         - event: change-merged
     success:
       gerrit: {}
-      sqlreporter:
+      mysql:
     failure:
       gerrit: {}
-      sqlreporter:
+      mysql:


### PR DESCRIPTION
The promote pipeline introduced in commit 2b7b0f21 uses the sqlreporter
keyword for success and failure events rather than the mysql key. The
sqlreporter key appears to be a newer Zuul construct.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>