### PR TITLE
use aboslute path for file lookups

### DIFF
--- a/roles/publish-charm/tasks/main.yaml
+++ b/roles/publish-charm/tasks/main.yaml
@@ -9,7 +9,7 @@
     - name: Upload oci-image to charmhub
       register: upload_oci_image_output
       vars:
-        metadata: "{{ lookup('file', zuul.project.src_dir+'/metadata.yaml') | from_yaml }}"
+        metadata: "{{ lookup('file', zuul.executor.work_root+'/'zuul.project.src_dir+'/metadata.yaml') | from_yaml }}"
       args:
         executable: /bin/bash
       shell: |


### PR DESCRIPTION
zuul.project.src_dir provides relative path from
home directory. In case of file lookups using
ansible builtin module lookup, add absolute paths
for lookups.
Add zuul.executor.work_root to get absolute path
for charm metadata.yaml in publish_charm task.