### PR TITLE
Add verbose to charmcraft commands

### DIFF
--- a/roles/publish-charm/tasks/main.yaml
+++ b/roles/publish-charm/tasks/main.yaml
@@ -36,8 +36,10 @@
       register: upload_charm_output
       args:
         chdir: "{{ zuul.project.src_dir }}"
-      command:
-        charmcraft upload --name {{ charm_build_name }} {{ charm_build_name }}.charm
+        executable: /bin/bash
+      shell: |
+        set -x
+        charmcraft upload -v --name {{ charm_build_name }} {{ charm_build_name }}.charm
         # TODO: The above command can error out with a message that says
         # upload with that digest already exists. This case need to be handled.
         # More details https://github.com/canonical/charmcraft/issues/826


### PR DESCRIPTION
Change the utility from command to shell for the
charm upload task.
Include verbosity for charmcraft command.