### PR TITLE
Enable voting for jammy-zed job

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -84,8 +84,7 @@
       jobs:
         - kinetic-zed:
             voting: false
-        - jammy-zed:
-            voting: false
+        - jammy-zed
         - jammy-yoga
 - project-template:
     name: charm-yoga-functional-jobs


### PR DESCRIPTION
This needs to be 'on' as we need to verify that jammy-zed is working.