### PR TITLE
Increase charm-build timeout from 3600 to 7200

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -146,7 +146,7 @@
 - job:
     name: charm-build
     description: Build a source charm into a deployable charm
-    timeout: 3600
+    timeout: 7200
     parent: tox
     provides: charm
     run: playbooks/charm/build.yaml


### PR DESCRIPTION
Increase charm-build timeout from 3600 to 7200

charm-octavia [1] and charm-octavia-diskimage-retrofit [2] were
hitting timeouts with timeout set to 3600.

[1] https://review.opendev.org/c/openstack/charm-octavia/+/850215
[2] https://review.opendev.org/c/openstack/charm-octavia-diskimage-retrofit/+/847500