### PR TITLE
Update charm-build job to run on jammy

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -18,24 +18,6 @@
   until: result is not failed
   retries: 10
   delay: 10
-- name: Purge lxd apt packages
-  become: true
-  apt:
-    name: "{{ item }}"
-    state: absent
-    purge: yes
-  loop:
-    - lxd
-    - lxd-client
-- name: Install lxd snap
-  become: true
-  snap:
-    name: lxd
-    channel: latest/stable
-  register: result
-  until: result is not failed
-  retries: 10
-  delay: 10
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -154,8 +154,8 @@
       - serverstack_cloud
     nodeset:
       nodes:
-        - name: xenial-medium
-          label: xenial-medium
+        - name: jammy-medium
+          label: jammy-medium
 
 - job:
     name: configure-juju


### PR DESCRIPTION
Previously the `charm-build` job had to run on a Xenial image in order for `charm-tools` to produce compatible reactive charms.

Since then all charms have been updated to make use of `charmcraft` to execute the build.

Charmcraft executes the build in LXD containers using the series specified in the charmcraft.yaml file, and as such there is no longer a need to keep the outer image on Xenial.