### PR TITLE
Revert "Update charm-build job to run on jammy"

### DIFF
--- a/roles/charm-build/tasks/main.yaml
+++ b/roles/charm-build/tasks/main.yaml
@@ -18,6 +18,24 @@
   until: result is not failed
   retries: 10
   delay: 10
+- name: Purge lxd apt packages
+  become: true
+  apt:
+    name: "{{ item }}"
+    state: absent
+    purge: yes
+  loop:
+    - lxd
+    - lxd-client
+- name: Install lxd snap
+  become: true
+  snap:
+    name: lxd
+    channel: latest/stable
+  register: result
+  until: result is not failed
+  retries: 10
+  delay: 10
 - name: Initialize lxd
   command: lxd init --auto
 - name: Print information about installed software

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -154,8 +154,8 @@
       - serverstack_cloud
     nodeset:
       nodes:
-        - name: jammy-medium
-          label: jammy-medium
+        - name: xenial-medium
+          label: xenial-medium
 
 - job:
     name: configure-juju


### PR DESCRIPTION
Ansible playbook not compatible with jammy atm. Also our zuul version does not support 3.10

This reverts commit 36de28090dc6498b3bba76ac703f07f729d3af20.