### PR TITLE
Capture juju show-unit

### DIFF
--- a/playbooks/juju/post.yaml
+++ b/playbooks/juju/post.yaml
@@ -14,6 +14,7 @@
           juju-crashdump \
             -o "{{ zuul.project.src_dir }}/log" \
             -m $model \
+            -a juju-show-unit \
             --as-root \
             -j '*' \
             /etc/apache2 \


### PR DESCRIPTION
Run "juju show-unit" to get a better understanding of the data in the relations which helps to troubleshoot why a given relation didn't run, or if it run but to check if the hook had all the data available.