### PR TITLE
Add integration in sqa lab

### DIFF
--- a/playbooks/sqalab/pre.yaml
+++ b/playbooks/sqalab/pre.yaml
@@ -1,0 +1,22 @@
+- hosts: all
+  vars:
+    sqalab:
+      auth:
+  tasks:
+    - name: 'install weebl-tools'
+      become: true
+      snap:
+        name: weebl-tools
+        classic: no
+      register: result
+      until: result is not failed
+      retries: 10
+      delay: 10
+    - name: 'render credentials.yaml'
+      template:
+        src: credentials.yaml.j2
+        dest: credentials.yaml
+    - name: Add credential
+      command: /snap/bin/weebl-tools.sqalab environment create --yaml credentials.yaml
+          #    - name: Clone charm-test-infra
+          #      command: git clone https://github.com/openstack-charmers/charm-test-infra /tmp/charm-test-infra

--- a/playbooks/sqalab/pre.yaml
+++ b/playbooks/sqalab/pre.yaml
@@ -1,7 +1,4 @@
 - hosts: all
-  vars:
-    sqalab:
-      auth:
   tasks:
     - name: 'install weebl-tools'
       become: true
@@ -18,5 +15,3 @@
         dest: credentials.yaml
     - name: Add credential
       command: /snap/bin/weebl-tools.sqalab environment create --yaml credentials.yaml
-          #    - name: Clone charm-test-infra
-          #      command: git clone https://github.com/openstack-charmers/charm-test-infra /tmp/charm-test-infra

--- a/playbooks/sqalab/run.yaml
+++ b/playbooks/sqalab/run.yaml
@@ -4,6 +4,7 @@
       command: |
         /snap/bin/weebl-tools.sqalab build add \
           --deployment-branch {{ sqalab.branch }} \
+          --deployment-repo {{ sqalab.repo }} \
           --lab {{ sqalab.lab }} \
           --format json \
       register: build_info

--- a/playbooks/sqalab/run.yaml
+++ b/playbooks/sqalab/run.yaml
@@ -11,6 +11,7 @@
     - name: 'wait for test run'
       command: /snap/bin/weebl-tools.sqalab build show --format json {{ (build_info.stdout | from_json)[0].uuid }}
       register: build_info
+      # To keep the playbook in sync with the sqalab we check the status every 10 min
       until: (build_info.stdout | from_json)[0].status in ["Finished", "Canceled", "Aborted"]
       delay: 600
       retries: 90

--- a/playbooks/sqalab/run.yaml
+++ b/playbooks/sqalab/run.yaml
@@ -14,8 +14,7 @@
       delay: 600
       retries: 90
     - name: 'print info'
-      command: |
-        set +x
+      shell: |
         /snap/bin/weebl-tools.sqalab build show {{ (build_info.stdout | from_json)[0].uuid }}
         cat << EOF
           Testrun results are summarized at:

--- a/playbooks/sqalab/run.yaml
+++ b/playbooks/sqalab/run.yaml
@@ -1,0 +1,25 @@
+- hosts: all
+  tasks:
+    - name: 'scedule test run'
+      command: |
+        /snap/bin/weebl-tools.sqalab build add \
+          --deployment-branch {{ sqalab.branch }} \
+          --lab {{ sqalab.lab }} \
+          --format json \
+      register: build_info
+    - name: 'wait for test run'
+      command: /snap/bin/weebl-tools.sqalab build show --format json {{ (build_info.stdout | from_json)[0].uuid }}
+      register: build_info
+      until: (build_info.stdout | from_json)[0].status in ["Finished", "Canceled", "Aborted"]
+      delay: 600
+      retries: 90
+    - name: 'print info'
+      command: |
+        set +x
+        /snap/bin/weebl-tools.sqalab build show {{ (build_info.stdout | from_json)[0].uuid }}
+        cat << EOF
+          Testrun results are summarized at:
+              https://solutions.qa.canonical.com/v2/testruns/{{ (build_info.stdout | from_json)[0].uuid }}
+          Generated artifacts are collected at:
+              https://oil-jenkins.canonical.com/artifacts/{{ (build_info.stdout | from_json)[0].uuid }}/index.html
+        EOF

--- a/playbooks/sqalab/templates/credentials.yaml.j2
+++ b/playbooks/sqalab/templates/credentials.yaml.j2
@@ -1,0 +1,12 @@
+production:
+  apikey: {{ sqalab.auth.apikey }}
+  env_name: {{ sqalab.auth.env_name }}
+  jenkins_url: {{ sqalab.auth.jenkins_url }}
+  smtp_from: {{ sqalab.auth.smtp_from }}
+  smtp_pass: {{ sqalab.auth.smtp_pass }}
+  smtp_port: {{ sqalab.auth.smtp_port }}
+  smtp_server: {{ sqalab.auth.smtp_server }}
+  smtp_user: {{ sqalab.auth.smtp_user }}
+  username: {{ sqalab.auth.username }}
+  uuid: {{ sqalab.auth.uuid }}
+  weebl_url: {{ sqalab.auth.weebl_url }}

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -755,3 +755,11 @@
       nodes:
         - name: focal-medium
           label: focal-medium
+- job:
+    name: sqa-integration
+    description: Sets up a sqalab connection for this test environment
+    pre-run: playbooks/sqalab/pre.yaml
+    run: playbooks/sqalab/run.yaml
+    abstract: true
+    secrets:
+      - sqalab

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -156,3 +156,38 @@
           oG5UgmSKhre5vkLgSqfxelkkvgVo4tXxDBWrT9fYfKj83Ee4TCZgEMnxanLmNznKHLEnu
           oukpwXp5qgb8+0e21bXBtZkxzfK5IEHZk6XInf8PYUWA18go1UETrbAdtb8QX094HWD1G
           6aAtCVUPfNStwkt+S4BxJctnIxN8M73GHiC42p2p4i+pYUVGSfLo1cAt3l9Jl8=
+- secret:
+    name: sqalab
+    data:
+      auth:
+        apikey: !encrypted/pkcs1-oaep
+        - PGD4jIppWbWM1RdzWgYjv5L58MDCmjkP6Ss4TASDH7Roel0bmP0jGTqDnlGqkIaRE0Vn8
+          0CLRvf5AL5RsanmTDDTRWaNRGO4JswF8H0PPA/5OEl26szmZ8u/p9Umtn5TaFky1UlNw3
+          BjFtRKXHCQJNHlWgjzbqVinX+3D/YbF1IezTlR7llZlzzhrNuUDJVpq1+FpIbL/7pNo02
+          kpmDLQf3hpciMTHlx+I7v4rX1kigjKlpqLAVz0aW0ZOi0q6TSXcM0KU+xLx6oRvOeSD4C
+          LZs4nYunrZ4hQXIP6QeNHXaxQDFrGXgwzYi/OXL342kR/cWGtdzY6M0nW8hphof00e9et
+          cXqqqktaHy8Qx5RN13C8o/baEmsZoFJdjdbIWmlyojS5ZeFyo865l3Xmvgp/DrW0X6ah7
+          YiMEZanxQNCeIPtBSclpeVJRcmLljM8/vVDYvVz4+OP0OQe0r9Iu6U73PCXlPAOwS6wEh
+          zg4Z0edfp+66mFfxKyeoRCXnLGdcqi2BQR8WuiQYNLg8KMH/vNFEQLnDFTrleOfoDYFES
+          18OoykkAFenrbHS32oJ5Pn6fpfM7v9Q8scFzyH1eByFbvwgM5RjlwFnljWX6HMIbiGgxx
+          W4QZtaElT2tdm8v8B+zsitc4DU8pJHySvfDp3JgJm1j+mDl93HeqgkSRnZTNXU=`
+        smtp_pass: !encrypted/pkcs1-oaep
+        - V7wwZsorZkPSwbY7omE40hrdzNzCLBLYfcEbqUr1WNPi0h22sRUs0JrkFCQ97PDQpkjrY
+          Zb9GjWIqORTG8O8bLLxmuzUcg5Ybcn3qUxDua/pz9XllyzphRr4IJ8bvd40LMuGtdkvdQ
+          pjjtJRRz7BVFwJGLzX6y5CLNQc5y7e30rjS0U3WWlmnlKE5OCbwJqwgPZzOArdmrfCX3z
+          +UPthBCRtLKvwjgzDn3MVVbPGPtU2G/pJs75g9Tc1e2w3XPGDJyoSLcHyRIx8XrZRSJrY
+          1DNnkUsFOSQf17FWrGO3UgIqAY96U0+0RlyocTdWR+AdA/l/Hj3ExRoHYReR7X+wV25qc
+          d6QHrw68dckXZMgFwpEg7UGrG4QXZ2/BMgdifG57kd98LvAYfHkzb/MdR6LVLpnakpY7q
+          FPgN8/7slI12+RgojWHYoq4a3UFRCccD7yFCaUsr9Oxkb1ypsalfmZTPgEJj8M1nC7uQB
+          2yDWB5+yqAVfiq/odmDkMcn5IftYDYXNXZ6WdF61f73qzv2TZg5VAnb4v0n/K/F6pjB5h
+          02NFOl4lComi7UL3OlQbU7zpqNpQNOSGe96YD4YzMKTbXH1MU7BsI82XPY0FrVj8I74TX
+          ITUyCbawECzwa8q+4/GmIdMDSe+ONNzQuFTeiiA2o0gVAYCDakAXvSPEIYsPHI=
+        env_name: production-focal
+        jenkins_url: http://10.131.231.80:8080
+        smtp_from: noreply@canonical.com
+        smtp_port: 465
+        smtp_server: smtp.canonical.com
+        smtp_user: canonical
+        username: ZuulBot
+        uuid: 0c00c563-7e9e-40ab-8db6-738d81aa1ce5
+        weebl_url: http://10.131.231.53:8080


### PR DESCRIPTION
Add playbooks, job, and secrets for integration between zuul and the SQA lab.

 - The integration relies on [https://github.com/canonical/weebl-tools](weebl-tools) (weebl in the sqa test server/dashboard). 
 - This PR can only be merged once the firewall rules between serverstack and the sqa lab are sorted out 
 - [Related PR in charmed-openstack-tester](https://github.com/openstack-charmers/charmed-openstack-tester/pull/88)