### PR TITLE
Move SQA integration tests, fix sqalab.run bug

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -14,6 +14,10 @@
               extra-config-paths:
                 - osci.yaml
                 - osci.d/
+          - openstack-charmers/sqa-integration-tester:
+              extra-config-paths:
+                - osci.yaml
+                - osci.d/
       opendev:
         untrusted-projects:
           - zuul/zuul-jobs:

--- a/playbooks/sqalab/run.yaml
+++ b/playbooks/sqalab/run.yaml
@@ -3,9 +3,9 @@
     - name: 'scedule test run'
       command: |
         /snap/bin/weebl-tools.sqalab build add \
-          --deployment-branch {{ sqalab.branch }} \
-          --deployment-repo {{ sqalab.repo }} \
-          --lab {{ sqalab.lab }} \
+          --deployment-branch {{ sqalab["branch"] }} \
+          --deployment-repo {{ sqalab["repo"]}} \
+          --lab {{ sqalab["lab"] }} \
           --format json \
       register: build_info
     - name: 'wait for test run'


### PR DESCRIPTION
- SQA integration tests are now moved to their own repository (https://github.com/openstack-charmers/sqa-integration-tester)
- As seen in the [last SQA integration test](http://10.245.164.110/t/openstack/build/1c2412e626ac40c1a3f3e13b1b1a60c8/console), the syntax of the variables readout needs fixing.