### PR TITLE
tox.ini: Fix passenv list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ passenv =
 basepython = python3
 
 [testenv:linters]
-whitelist_externals = bash
+allowlist_externals = bash
 # Add dependencies here since other jobs use python2 and zuul requires
 # python3.
 deps =
@@ -44,7 +44,7 @@ commands =
     xargs -t -n1 ansible-lint'
 
 [testenv:ansible]
-whitelist_externals = bash
+allowlist_externals = bash
 setenv =
   ANSIBLE_LIBRARY= {toxinidir}/tests/fake-ansible
   # NOTE(pabelanger): if you'd like to run tox -elinters locally,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,13 @@ envlist = linters
 skipsdist = True
 
 [testenv]
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+passenv =
+    http_proxy
+    HTTP_PROXY
+    https_proxy
+    HTTPS_PROXY
+    no_proxy
+    NO_PROXY
 basepython = python3
 
 [testenv:linters]


### PR DESCRIPTION
Tox now chokes on spaces in the `passenv` key and requires it to be a comma separated or multi-line list.