### PR TITLE
Update base job stable branches for various charms

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -13,7 +13,7 @@
     secrets: &log_clouds
       # - serverstack_cloud
       - artifact_cloud
-    branches: ^(?!stable\/(21\.10|train|ussuri|victoria|wallaby|xena|yoga|zed|luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)).*$
+    branches: ^(?!stable\/(1\.5|1\.6|1\.7|1\.8|4\.0|4\.1|4\.2|20\.03|20\.12|21\.09|22\.03|22\.09|21\.10|focal|jammy|train|ussuri|victoria|wallaby|xena|yoga|zed|luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)).*$
     # vars:
     #   tox_environment:
     #     HTTP_PROXY: "http://squid.internal:3128/"
@@ -33,7 +33,7 @@
         - name: focal-medium
           label: focal-medium
     secrets: *log_clouds
-    branches: ^stable\/(21\.10|train|ussuri|victoria|wallaby|xena|yoga|zed|luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2).*$
+    branches: ^stable\/(1\.5|1\.6|1\.7|1\.8|4\.0|4\.1|4\.2|20\.03|20\.12|21\.09|22\.03|22\.09|21\.10|focal|jammy|train|ussuri|victoria|wallaby|xena|yoga|zed|luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2).*$
     vars:
       # NOTE(coreycb): This job is for stable branches <= stable/zed. Tox 4
       # requires changes to be compatible, therefore we pin tox <4 for current


### PR DESCRIPTION
Add the following charm stable branches to the regular expressions:
* trilio charms: stable/4.0, stable/4.1, stable/4.2
* rabbitmq-server, pacemaker-remote, hacluster charms: stable/focal
* rabbitmq-server, pacemaker-remote, hacluster, mysql-innodb, mysql-router, openstack-loadbalancer charms: stable/jammy
* vault charm: stable/1.5, stable/1.6, stable/1.7, stable/1.8
* ovn charms: stable/20.03, stable/20.12, stable/21.09, stable/22.03, stable/22.09