### PR TITLE
Add TEST_REGISTRY_PREFIX environment variable

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -328,6 +328,7 @@
         # Enable workaround for bug http://pad.lv/1987332
         # https://github.com/openstack-charmers/zaza/commit/fc268181e8da1cb4293328fa2e78082873d98697
         TEST_ZAZA_BUG_LP1987332: "1"
+        TEST_REGISTRY_PREFIX: "10.245.164.190:5000"
       tox_envlist: func-target
     secrets:
       - serverstack_cloud


### PR DESCRIPTION
The TEST_REGISTRY_PREFIX environment variable is consumed by zaza-openstack-test when magnum is deployed, this registry contains the images needed for successfull k8s deployment, for more details see zaza.openstack.charm_tests.tempest.utils for more details.