### PR TITLE
Add lunar-antelope and jammy-antelope

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -450,6 +450,17 @@
     vars:
       tox_extra_args: '-- bionic-queens'
 - job:
+    name: lunar-antelope
+    description: Run a functional test against lunar-antelope
+    parent: func-target-pre-jobs
+    dependencies:
+      - name: tox-py310
+        soft: true
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: '-- lunar-antelope'
+- job:
     name: kinetic-zed
     description: Run a functional test against kinetic-zed
     parent: func-target-pre-jobs
@@ -501,6 +512,17 @@
       - charm-build
     vars:
       tox_extra_args: '-- groovy-victoria'
+- job:
+    name: jammy-antelope
+    description: Run a functional test against jammy-antelope
+    parent: func-target-pre-jobs
+    dependencies:
+      - name: tox-py310
+        soft: true
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: '-- jammy-antelope'
 - job:
     name: jammy-zed
     description: Run a functional test against jammy-zed

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -27,6 +27,10 @@
     description: |
       placeholder
 - project-template:
+    name: openstack-python3-charm-antelope-jobs
+    description: |
+      placeholder
+- project-template:
     name: openstack-python3-charm-zed-jobs
     description: |
       placeholder
@@ -76,6 +80,16 @@
         - bionic-stein
         - bionic-queens
         - xenial-mitaka
+- project-template:
+    name: charm-antelope-functional-jobs
+    description: |
+      The default set of antelope functional test jobs for the OpenStack Charms
+    check:
+      jobs:
+        - lunar-antelope:
+            voting: false
+        - jammy-antelope
+        - jammy-zed
 - project-template:
     name: charm-zed-functional-jobs
     description: |
@@ -242,6 +256,19 @@
         - tox-py39
 - project-template:
     name: charm-zed-unit-jobs
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        # NOTE(ajkavanagh) disabled until we can get zuul, ansible and py310 on
+        # jammy to play together.
+        # NOTE(icey) BUT REALLY, DO NOT ENABLE THE FOLLOWING UNTIL YOU KNOW WE CAN
+        # RUN A 3.10 JOB ON ZOSCI.
+        #- tox-py310
+- project-template:
+    name: charm-antelope-unit-jobs
     description: |
       The default set of unit tests and lint checks for the OpenStack Charms
     check:


### PR DESCRIPTION
Add the lunar-antelope and jammy-antelope targets for running tests on 23.04 and 22.04 with the Ubuntu Cloud Archive.