### PR TITLE
Reduce func-test concurrency from 12 to 10

### DIFF
--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,3 +1,3 @@
 - semaphore:
     name: functional-test
-    max: 12
+    max: 10


### PR DESCRIPTION
The cloud where zosci runs has reduced its cpu overcommit to reduce the amount of pressure that the CI jobs are putting on the control plane which has been leading to outages, this is a change that goes into that direction, less jobs, but more reliable runs.