### PR TITLE
Fix project-templates branches key.

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -90,61 +90,69 @@
               - master
               - stable/2023.1
         - focal-wallaby:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - focal-victoria:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - focal-ussuri:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - bionic-ussuri:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - bionic-train:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - bionic-stein:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - bionic-queens:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - xenial-mitaka:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
 - project-template:
     name: charm-zed-functional-jobs
     description: |
@@ -248,33 +256,37 @@
         - charm-build
         - osci-lint
         - tox-py35:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - tox-py36:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - tox-py37:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         - tox-py38:
-            branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
-            branches: ^stable\/(4\.0|4\.1|4\.2)$
-            branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
-            branches: ^stable\/(focal|jammy)$
-            branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
-            branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
+            branches:
+              - ^stable\/(1\.5|1\.6|1\.7|1\.8)$
+              - ^stable\/(4\.0|4\.1|4\.2)$
+              - ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
+              - ^stable\/(focal|jammy)$
+              - ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
+              - ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$
         # NOTE(ajkavanagh) disabled until we can get zuul, ansible and py310 on
         # jammy to play together.
         # NOTE(icey) BUT REALLY, DO NOT ENABLE THE FOLLOWING UNTIL YOU KNOW WE CAN


### PR DESCRIPTION
branches must be a list of regexp.

  The key "branches" appears more than once; duplicate keys are not
  permitted.

The error appears in the following stanza:

  branches: ^stable\/(1\.5|1\.6|1\.7|1\.8)$
              branches: ^stable\/(4\.0|4\.1|4\.2)$
              branches: ^stable\/(20\.03|20\.12|21\.09|21\.10|22\.03|22\.09)$
              branches: ^stable\/(focal|jammy)$
              branches: ^stable\/(train|ussuri|victoria|wallaby|xena|yoga|zed)$
              branches: ^stable\/(luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2)$