### PR TITLE
Run charm-build job on focal-medium

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -192,8 +192,8 @@
       - serverstack_cloud
     nodeset:
       nodes:
-        - name: xenial-medium
-          label: xenial-medium
+        - name: focal-medium
+          label: focal-medium
 
 - job:
     name: configure-juju


### PR DESCRIPTION
All charm builds now happen via charmcraft which launches a LXD container with the base specified in charmcraft.yaml making the Ubuntu series where the job runs less relevant, and having a newer version is better from the perspective of the kernel, snapd and lxd.