### PR TITLE
Set jammy-antelope job to non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -82,6 +82,7 @@
               - master
               - stable/2023.1
         - jammy-antelope:
+            voting: false
             branches:
               - master
               - stable/2023.1


### PR DESCRIPTION
The antelope charm batch results in many circular
dependencies due to bundles that are using charms
that do not yet have antelope support enabled.
Voting needs to be re-enabled once the antelope
batch is merged.