### PR TITLE
Reduce concurrency for func-test from 10 to 8

### DIFF
--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,3 +1,3 @@
 - semaphore:
     name: functional-test
-    max: 10
+    max: 8


### PR DESCRIPTION
The undercloud lost a hypervisor (caipora), so now we are seeing many jobs failing with "No valid host found" errors.