### PR TITLE
Update charm-functional-jobs stable branches

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -81,14 +81,26 @@
             branches:
               - master
               - stable/2023.1
+              - stable/1.8
+              - stable/23.03
+              - stable/quincy.2
+              - stable/jammy
         - jammy-antelope:
             branches:
               - master
               - stable/2023.1
+              - stable/1.8
+              - stable/23.03
+              - stable/quincy.2
+              - stable/jammy
         - jammy-zed:
             branches:
               - master
               - stable/2023.1
+              - stable/1.8
+              - stable/23.03
+              - stable/quincy.2
+              - stable/jammy
         - focal-wallaby:
             branches: ^stable\/(1\.5|1\.6|1\.7|1\.8|4\.0|4\.1|4\.2|20\.03|20\.12|21\.09|22\.03|22\.09|21\.10|focal|jammy|train|ussuri|victoria|wallaby|xena|yoga|zed|luminous|mimic|nautilus|octopus|pacific|quincy|quincy\.2).*$
         - focal-victoria:


### PR DESCRIPTION
This update adds non-openstack stable branch names to jammy-zed, jammy-antelope, and lunar-antelope jobs. If any of the charms with corresponding stable branch names want to run the generic charm-functional-jobs in their .zuul.yaml, they need zosci to understand their stable branch names.