### PR TITLE
Add Watcher

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -118,6 +118,7 @@
           - openstack/charm-trilio-wlm: *default-project
           - openstack/charm-vault: *default-project
           - openstack/charm-watcher: *default-project
+          - openstack/charm-watcher-dashboard: *default-project
           - x/charm-ovn-central: *default-project
           - x/charm-ovn-central-k8s: *default-project
           - x/charm-ovn-chassis: *default-project

--- a/main.yaml
+++ b/main.yaml
@@ -117,6 +117,7 @@
           - openstack/charm-trilio-horizon-plugin: *default-project
           - openstack/charm-trilio-wlm: *default-project
           - openstack/charm-vault: *default-project
+          - openstack/charm-watcher: *default-project
           - x/charm-ovn-central: *default-project
           - x/charm-ovn-central-k8s: *default-project
           - x/charm-ovn-chassis: *default-project


### PR DESCRIPTION
This PR registers two new charms:
* charm-watcher, principal charm to configure OpenStack Watcher
* charm-watcher-dashboard, subordinate charm that extends openstack-charm to configure the watcher-ui plugin.

