### PR TITLE
Turn jammy-bobcat voting off

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -86,6 +86,7 @@
               - stable/reef
               - stable/jammy
         - jammy-bobcat:
+            voting: false
             branches:
               - master
               - stable/2023.2


### PR DESCRIPTION
This is required until at least the initial branch of bobcat enablement is added to the charms.