### PR TITLE
Increase charm-build timeout from 2h to 3h

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -172,7 +172,7 @@
 - job:
     name: charm-build
     description: Build a source charm into a deployable charm
-    timeout: 7200
+    timeout: 10800  # 3hr
     parent: tox
     provides: charm
     run: playbooks/charm/build.yaml


### PR DESCRIPTION
charm-octavia[1] and charm-octavia-diskimage-retrofit[2] were hitting timeouts with timeout set to 7200.

[1] https://review.opendev.org/c/openstack/charm-octavia/+/858608
[2] https://review.opendev.org/c/openstack/charm-octavia-diskimage-retrofit/+/896680