### PR TITLE
Add noop-jobs project template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1,4 +1,18 @@
 - project-template:
+    name: noop-jobs
+    description: |
+      This template runs no jobs, it is needed if a project does not use
+      any single job so that changes can get merged.
+
+      Do not use this with projects that have jobs defined in the gate
+      pipeline.
+    check:
+      jobs:
+        - noop
+    gate:
+      jobs:
+        - noop
+- project-template:
     name: python35-charm-jobs
     description: |
       placeholder


### PR DESCRIPTION
The noop-jobs project template allows projects to define a check and/or gate job that always succeeds, this is mainly (if not only) used by git branches that have been cleaned up, for example:
https://opendev.org/openstack/charm-mysql-innodb-cluster/commit/0d8e7accae509c4ae332c169463685e16699d600

The `noop` job is a virtual job defined by Zuul itself, see https://opendev.org/zuul/zuul/src/commit/d1ffc204e4b4955f2a47e7e37618fcf13bb1b9fd/zuul/model.py#L8018-L8029

This job template definition was borrowed from https://opendev.org/openstack/openstack-zuul-jobs/src/branch/master/zuul.d/project-templates.yaml#L18