### PR TITLE
Run jammy-antelope on stable/2023.2 branch

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -128,6 +128,7 @@
               - main
               - master
               - stable/2023.1
+              - stable/2023.2
               - stable/1.8
               - stable/23.03
               - stable/quincy.2


### PR DESCRIPTION
The stable/2023.2 needs to test the correct functioning of 2023.1/antelope to service users coming from an openstack upgrade.