### PR TITLE
Remove lunar-antelope from the master branch

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -116,8 +116,6 @@
         - lunar-antelope:
             voting: false
             branches:
-              - main
-              - master
               - stable/2023.1
               - stable/1.8
               - stable/23.03


### PR DESCRIPTION
For the charm-functional-jobs remove the lunar-antelope job as it's no
longer needed.
