### PR TITLE
Add OpenStack 2024.1 (Caracal) jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -186,6 +186,22 @@
       python_version: '3.11'
 
 - job:
+    name: tox-py312
+    parent: tox
+    description: |
+      Run unit tests for a Python project under cPython version 3.12.
+
+      Uses tox with the ``py312`` environment.
+
+    nodeset:
+      nodes:
+        - name: noble-medium
+          label: noble-medium
+    vars:
+      tox_envlist: py312
+      python_version: '3.12'
+
+- job:
     name: charm-build
     description: Build a source charm into a deployable charm
     timeout: 10800  # 3hr

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -478,6 +478,18 @@
     vars:
       tox_extra_args: '-- bionic-queens'
 - job:
+    name: noble-caracal
+    description: Run a functional test against noble-caracal
+    parent: func-target-pre-jobs
+    dependencies:
+      - name: tox-py312
+        soft: true
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: '-- noble-caracal'
+      juju_snap_channel: '3.3/stable'
+- job:
     name: mantic-bobcat
     description: Run a functional test against mantic-bobcat
     parent: func-target-pre-jobs
@@ -551,6 +563,18 @@
       - charm-build
     vars:
       tox_extra_args: '-- groovy-victoria'
+- job:
+    name: jammy-caracal
+    description: Run a functional test against jammy-caracal
+    parent: func-target-pre-jobs
+    dependencies:
+      - name: tox-py310
+        soft: true
+      - osci-lint
+      - charm-build
+    vars:
+      tox_extra_args: '-- jammy-caracal'
+      juju_snap_channel: '3.3/stable'
 - job:
     name: jammy-bobcat
     description: Run a functional test against jammy-bobcat

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -77,6 +77,10 @@
     description: |
       placeholder
 - project-template:
+    name: openstack-tox-py312
+    description: |
+      placeholder
+- project-template:
     name: openstack-cover-jobs
     description: |
       placeholder
@@ -139,8 +143,6 @@
               - stable/jammy
         - jammy-antelope:
             branches:
-              - main
-              - master
               - stable/2023.1
               - stable/2023.2
               - stable/1.8
@@ -393,6 +395,21 @@
         # NOTE(icey) BUT REALLY, DO NOT ENABLE THE FOLLOWING UNTIL YOU KNOW WE CAN
         # RUN A 3.11 JOB ON ZOSCI.
         #- tox-py311
+- project-template:
+    name: charm-unit-jobs-py312
+    description: |
+      The default set of unit tests and lint checks for the OpenStack Charms
+    check:
+      jobs:
+        - charm-build
+        - osci-lint
+        # NOTE: disabled until we can get zuul, ansible and py312 on caracal to
+        # play together.
+        #
+        # NOTE: BUT REALLY, DO NOT ENABLE THE FOLLOWING UNTIL YOU KNOW WE CAN
+        # RUN A 3.12 JOB ON ZOSCI.
+        #
+        #- tox-py312
 - project-template:
     name: charm-yoga-unit-jobs
     description: |

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -94,6 +94,22 @@
       The default set of functional test jobs for the OpenStack Charms
     check:
       jobs:
+        - noble-caracal:
+            voting: false
+            branches:
+              - main
+              - master
+              - stable/2024.1  # OpenStack
+              - stable/24.03   # OVN
+              - stable/noble   # Ubuntu
+        - jammy-caracal:
+            voting: false
+            branches:
+              - main
+              - master
+              - stable/2024.1  # OpenStack
+              - stable/24.03   # OVN
+              - stable/noble   # Ubuntu
         - mantic-bobcat:
             voting: false
             branches:


### PR DESCRIPTION
Two new job templates are added (noble-caracal and jammy-caracal) that run when changes are detected in the following branches:

  - main
  - master
  - stable/2024.1  # OpenStack
  - stable/24.03   # OVN
  - stable/noble   # Ubuntu

Depends-On: https://github.com/openstack-charmers/zaza/pull/608