### PR TITLE
Increase the timeout for func-target job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -217,7 +217,7 @@
     # abstract job; use as parent for other jobs
     abstract: true
     parent: configure-juju
-    timeout: 14400
+    timeout: 18000
     attempts: 4
     semaphore: functional-test
     # as an alternate to semaphores, or along side them, we could define


### PR DESCRIPTION
There are some jobs that are timing out after 4 hours because of this timeout. Increasing to 5 hours for now to help these jobs complete.