### PR TITLE
Revert pull request 305 add-index-html

### DIFF
--- a/roles/upload-swift/tasks/main.yaml
+++ b/roles/upload-swift/tasks/main.yaml
@@ -36,7 +36,7 @@
       zuul_return:
         data:
           zuul:
-            log_url: "https://openstack-ci-reports.ubuntu.com/artifacts{{ upload_results.url.split('zosci-artifacts') | last }}/index.html"
+            log_url: "https://openstack-ci-reports.ubuntu.com/artifacts{{ upload_results.url.split('zosci-artifacts') | last }}/"
     - name: Print upload failures
       debug:
         var: upload_results.upload_failures


### PR DESCRIPTION
This commit reverses a change that added index.html at the end of the log_url for Zuul logs. As far as I can tell this is causing the URL to be wrong and cause 404 errors. I think removing the `index.html` should fix this. I'm not sure why this is happening in the first place, unfortunately.