### PR TITLE
Install the juju snap as classic only when the channel is 2.9

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -19,7 +19,12 @@
       become: true
       snap:
         name: juju
-        classic: yes
+        # NOTE(freyes): Juju's '2.9' snap track publishes a snap with the
+        # classic confinement, while juju>=3.1 uses a strict confinement,
+        # instead of asking users to understand this, we encapsulate this
+        # information into this inline-if where if the juju_snap_channel has the
+        # '2.9/' prefix the classic field is set to True, otherwise False.
+        classic: "{{ True if juju_snap_channel and juju_snap_channel.startswith('2.9/') else False }}"
         channel: "{{ juju_snap_channel }}"
       register: result
       until: result is not failed


### PR DESCRIPTION
Juju's '2.9' snap track publishes a snap with the classic confinement, while juju>=3.1 uses a strict confinement, instead of asking users to understand this, we encapsulate this information into the ansible task.