### PR TITLE
Rewrite jinja2 snippet to determine if juju snap should be classic

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -24,7 +24,7 @@
         # instead of asking users to understand this, we encapsulate this
         # information into this inline-if where if the juju_snap_channel has the
         # '2.9/' prefix the classic field is set to True, otherwise False.
-        classic: "{{ True if juju_snap_channel and juju_snap_channel.startswith('2.9/') else False }}"
+        classic: "{{ juju_snap_channel is defined and juju_snap_channel.startswith('2.9/') }}"
         channel: "{{ juju_snap_channel }}"
       register: result
       until: result is not failed


### PR DESCRIPTION
The commit 16b1561 introduced a dynamic evaluation to set the `classic` property to true/false when installing the juju snap, although that line produces a "False" which Ansible is evaluating to true.

This change takes a different approach dropping the use of an inline-if which was producing a string value, now it's being used a conditional expression to force the evaluation as a boolean.