### PR TITLE
Do not use /tmp for intermediate files.

### DIFF
--- a/playbooks/juju/pre.yaml
+++ b/playbooks/juju/pre.yaml
@@ -74,20 +74,20 @@
     - name: Add credential
       command: /snap/bin/juju add-credential {{ serverstack_cloud.region_name }} --client -f credentials.yaml
     - name: Clone charm-test-infra
-      command: git clone https://github.com/openstack-charmers/charm-test-infra /tmp/charm-test-infra
+      command: git clone https://github.com/openstack-charmers/charm-test-infra /home/ubuntu/charm-test-infra
     - name: 'Bootstrap Controller'
       command: |
         /snap/bin/juju bootstrap \
           --bootstrap-constraints="virt-type=kvm cores=4 mem=8G" \
           --constraints=virt-type=kvm \
           --auto-upgrade=false \
-          --model-default=/tmp/charm-test-infra/juju-configs/model-default-serverstack.yaml \
-          --config=/tmp/charm-test-infra/juju-configs/controller-default.yaml \
+          --model-default=/home/ubuntu/charm-test-infra/juju-configs/model-default-serverstack.yaml \
+          --config=/home/ubuntu/charm-test-infra/juju-configs/controller-default.yaml \
           {{ serverstack_cloud.region_name }}/{{ serverstack_cloud.region_name }}
     - name: 'Configure cloudinit-userdata model-default'
       shell:
         cmd: |
-          cat > /tmp/cloudinit-userdata.yaml << EOF
+          cat > /home/ubuntu/cloudinit-userdata.yaml << EOF
           cloudinit-userdata: |
             apt:
               conf: |
@@ -101,6 +101,6 @@
               - systemctl daemon-reload
               - systemctl restart systemd-resolved
           EOF
-          /snap/bin/juju model-default /tmp/cloudinit-userdata.yaml
+          /snap/bin/juju model-default /home/ubuntu/cloudinit-userdata.yaml
       args:
         executable: /bin/bash


### PR DESCRIPTION
The juju snap in strict mode can't access /tmp. This change moves the charm-test-infra and other temporary files under /home/ubuntu to allow the juju client read them.