### PR TITLE
Add default juju model if needed.

### DIFF
--- a/roles/juju-setup/tasks/main.yaml
+++ b/roles/juju-setup/tasks/main.yaml
@@ -82,6 +82,12 @@
       --model-default=/home/ubuntu/charm-test-infra/juju-configs/model-default-serverstack.yaml \
       --config=/home/ubuntu/charm-test-infra/juju-configs/controller-default.yaml \
       {{ serverstack_cloud.region_name }}/{{ serverstack_cloud.region_name }}
+- name: 'Add default juju model if needed'
+  shell:
+    cmd: |
+      /snap/bin/juju show-model default || /snap/bin/juju add-model default
+  args:
+    executable: /bin/bash
 - name: 'Configure cloudinit-userdata model-default'
   shell:
     cmd: |


### PR DESCRIPTION
Juju stopped creating a default model when a controller is bootstrapped, this new task checks for the existence of the model, if it's not present, it creates it.