### PR TITLE
Handle constraints from a URL

### DIFF
--- a/playbooks/juju/run.yaml
+++ b/playbooks/juju/run.yaml
@@ -2,6 +2,7 @@
   roles:
     - setup-networking-env
     - charm-build
+    - handle-constraints-url
     - handle-func-test-pr
     - revoke-sudo
     - setup-test-fixtures

--- a/roles/handle-constraints-url/defaults/main.yaml
+++ b/roles/handle-constraints-url/defaults/main.yaml
@@ -1,0 +1,1 @@
+pip_constraints_url: null

--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -1,0 +1,22 @@
+- name: Create temporary file to store the constraints
+  ansible.builtin.tempfile:
+    path: /home/ubuntu/
+    prefix: "constraints."
+    suffix: ".txt"
+  when: pip_constraints_url is defined
+  register: constraints_file
+
+- name: GET the constraints file
+  get_url:
+    url: "{{ pip_constraints_url }}"
+    dest: "{{ constraints_file.path }}"
+    mode: 0444
+  when: constraints_file is defined and pip_constraints_url is defined
+
+- name: Record file location
+  set_fact:
+    tox_constraints_env:
+      TOX_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
+      # Backward compatibility, to be removed
+      UPPER_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
+  when: constraints_file is defined and pip_constraints_url is defined


### PR DESCRIPTION
The tox job[0] accepts the tox_constraints_file variable, although its implementation checks that the string references a locally available file[1]. This prevents from passing a url to pip.

This change reads the content from a url passed via pip_constraints_url and renders it in a temporary file that gets referenced to be used by tox.

[0] https://zuul-ci.org/docs/zuul-jobs/latest/python-jobs.html#jobvar-tox.tox_constraints_file
[1] https://opendev.org/zuul/zuul-jobs/src/branch/master/roles/tox/tasks/main.yaml