### PR TITLE
Get the constraints file only when holds a valid value

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -3,7 +3,6 @@
     path: /home/ubuntu/
     prefix: "constraints."
     suffix: ".txt"
-  when: pip_constraints_url is defined
   register: constraints_file
 
 - name: GET the constraints file
@@ -11,7 +10,12 @@
     url: "{{ pip_constraints_url }}"
     dest: "{{ constraints_file.path }}"
     mode: 0444
-  when: constraints_file is defined and pip_constraints_url is defined
+  when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url != null and pip_constraints_url|length > 0
+
+- name: Get stat of temporary constraints file
+  ansible.builtin.stat:
+    path: "{{ constraints_file.path }}"
+  register: constraints_stat
 
 - name: Record file location
   set_fact:
@@ -19,4 +23,4 @@
       TOX_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
       # Backward compatibility, to be removed
       UPPER_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
-  when: constraints_file is defined and pip_constraints_url is defined
+  when: constraints_stat.size > 0


### PR DESCRIPTION
This change makes the handle-constraints-url validate more aggressively the pip_constraints_url holds a value that can be used, also a new task is introduced to only use the constraints file when its size is larger than zero.

```
TASK [handle-constraints-url : GET the constraints file]
focal-medium | ERROR
focal-medium | {
focal-medium |   "dest": "/home/ubuntu/constraints.a7h1xj9v.txt",
focal-medium |   "elapsed": 0,
focal-medium |   "gid": 1000,
focal-medium |   "group": "ubuntu",
focal-medium |   "mode": "0600",
focal-medium |   "msg": "An unknown error occurred: a bytes-like object is required, not 'str'",
focal-medium |   "owner": "ubuntu",
focal-medium |   "size": 0,
focal-medium |   "state": "file",
focal-medium |   "uid": 1000,
focal-medium |   "url": null
focal-medium | }
```