### PR TITLE
Use `is not None` instead of `!= null`.

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -10,7 +10,7 @@
     url: "{{ pip_constraints_url }}"
     dest: "{{ constraints_file.path }}"
     mode: 0444
-  when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url != null and pip_constraints_url|length > 0
+  when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url is not None and pip_constraints_url|length > 0
 
 - name: Get stat of temporary constraints file
   ansible.builtin.stat:


### PR DESCRIPTION
The value passed in the `when` stanza uses None instead of null.

Fixes the error: `'null' is undefined`