### PR TITLE
Use `none` instead of `None`.

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -10,7 +10,7 @@
     url: "{{ pip_constraints_url }}"
     dest: "{{ constraints_file.path }}"
     mode: 0444
-  when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url is not None and pip_constraints_url|length > 0
+  when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url is not none and pip_constraints_url|length > 0
 
 - name: Get stat of temporary constraints file
   ansible.builtin.stat:


### PR DESCRIPTION
Jinja2 tests against `none` (lowercase). When using `None` (capitalized), the following error is raise:

The conditional check '...' failed. The error was: template error while templating string: no test named 'None'.

See https://github.com/pallets/jinja/issues/520 for more details.

Issue seen in the gate at
https://openstack-ci-reports.ubuntu.com/artifacts/b6d/908775/3/check/jammy-zed/b6df748/job-output.txt