### PR TITLE
Check the stat dictionary's size, not the variable's size

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -23,4 +23,4 @@
       TOX_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
       # Backward compatibility, to be removed
       UPPER_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
-  when: constraints_stat.size > 0
+  when: constraints_stat.stat.exists and constraints_stat.stat.size > 0


### PR DESCRIPTION
The ansible.builtin.stat module returns a dictionary where the key to use is 'stat' in order to get the file stats. Add the missing stat key. Failure to do this causes the task to fail with size not being a key in the dictionary.

ref: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/stat_module.html#ansible-collections-ansible-builtin-stat-module