### PR TITLE
Set TEST_CONSTRAINTS_FILE instead of TOX_CONSTRAINTS_FILE

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -20,7 +20,5 @@
 - name: Record file location
   set_fact:
     tox_constraints_env:
-      TOX_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
-      # Backward compatibility, to be removed
-      UPPER_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
+      TEST_CONSTRAINTS_FILE: "{{ constraints_file.path }}"
   when: constraints_stat.stat.exists and constraints_stat.stat.size > 0


### PR DESCRIPTION
This change updates the handle-constraints-url role to set the TEST_CONSTRAINTS_URL instead of TOX_CONSTRAINTS_FILE to avoid collision with upstream's zuul.

Related-Pr: https://github.com/openstack-charmers/release-tools/pull/295