### PR TITLE
Set constraints for bobcat jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -514,6 +514,12 @@
       - charm-build
     vars:
       tox_extra_args: '-- mantic-bobcat'
+      # NOTE: the next two variables need to be updated together, because the
+      # constraints have pinning to install the right version of python-libjuju
+      # based on what snap channel is being used to bootstrap the controller
+      # from.
+      juju_snap_channel: '2.9/stable'
+      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
 - job:
     name: lunar-antelope
     description: Run a functional test against lunar-antelope
@@ -600,6 +606,12 @@
       - charm-build
     vars:
       tox_extra_args: '-- jammy-bobcat'
+      # NOTE: the next two variables need to be updated together, because the
+      # constraints have pinning to install the right version of python-libjuju
+      # based on what snap channel is being used to bootstrap the controller
+      # from.
+      juju_snap_channel: '2.9/stable'
+      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
 - job:
     name: jammy-antelope
     description: Run a functional test against jammy-antelope


### PR DESCRIPTION
The *-bobcat jobs are run by master branch AND stable/2023.2, while the former would be OK to be moved to use juju-3.x, the latter is not.

Without this change, bobcat jobs running in master will install juju-2.9, but zaza from master making it install libjuju-3.x. This change introduces the constraint which will be honored by master and discarded by stable/2023.2 although that stable branch installs zaza from stable/bobcat which has libjuju pinned to `<3.0`.