### PR TITLE
Remove mantic from dev

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -117,8 +117,6 @@
         - mantic-bobcat:
             voting: false
             branches:
-              - main
-              - master
               - stable/2023.2
               - stable/1.8
               - stable/23.09
@@ -132,14 +130,6 @@
               - stable/1.8
               - stable/23.09
               - stable/reef
-              - stable/jammy
-        - lunar-antelope:
-            voting: false
-            branches:
-              - stable/2023.1
-              - stable/1.8
-              - stable/23.03
-              - stable/quincy.2
               - stable/jammy
         - jammy-antelope:
             branches:


### PR DESCRIPTION
 and remove lunar job,Lunar is EOL so stop testing it for antelope.  Mantic is only for 2023.2
and therefore is removed for 2024.1 testing (curently main/master).
Mantic will be removed when it goes EOL.