### PR TITLE
Force download of constraints files

### DIFF
--- a/roles/handle-constraints-url/tasks/main.yaml
+++ b/roles/handle-constraints-url/tasks/main.yaml
@@ -10,6 +10,7 @@
     url: "{{ pip_constraints_url }}"
     dest: "{{ constraints_file.path }}"
     mode: 0444
+    force: true
   when: constraints_file is defined and pip_constraints_url is defined and pip_constraints_url is not none and pip_constraints_url|length > 0
 
 - name: Get stat of temporary constraints file


### PR DESCRIPTION
Ansible's get_url module uses the last modified time of an existing file on disk to only download files that have potentially changed. The handle-constraints-url role will create a temporary temporary file to store the constraints file, which leaves the last modified time as extremely recent. This causes the remote webserver to respond with an HTTP 304 (content not modified) and the constraints do not get properly set.

This change addresses this by adding force: true to the get_url module which will always download the specified file and not use the file's last modified timestamp.