### PR TITLE
Comment out juju_snap_channel and pip_constraints_url

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -506,8 +506,8 @@
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      juju_snap_channel: '3.1/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt'
+      # juju_snap_channel: '3.1/stable'
+      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt'
 - job:
     name: mantic-bobcat
     description: Run a functional test against mantic-bobcat
@@ -523,8 +523,8 @@
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      juju_snap_channel: '2.9/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
+      # juju_snap_channel: '2.9/stable'
+      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
 - job:
     name: lunar-antelope
     description: Run a functional test against lunar-antelope
@@ -603,8 +603,8 @@
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      juju_snap_channel: '3.1/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt'
+      # juju_snap_channel: '3.1/stable'
+      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt'
 - job:
     name: jammy-bobcat
     description: Run a functional test against jammy-bobcat
@@ -620,8 +620,8 @@
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      juju_snap_channel: '2.9/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
+      # juju_snap_channel: '2.9/stable'
+      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza/master/constraints-juju29.txt'
 - job:
     name: jammy-antelope
     description: Run a functional test against jammy-antelope


### PR DESCRIPTION
Make the gate to use juju 2.9 since zaza has been exhibiting different failures when trying to be used with juju 3.x, this will be kept until zaza gets more robust.

Depends-On: https://github.com/openstack-charmers/zaza/pull/652