### PR TITLE
Add stable/2024.1 branch to jammy-bobcat for c-f-jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -125,6 +125,7 @@
             branches:
               - main
               - master
+              - stable/2024.1
               - stable/2023.2
               - stable/1.8
               - stable/23.09


### PR DESCRIPTION
i.e. we want jammy-bobcat bundle to run for charm-functional-jobs on the
stable/2024.1 branch of repositories.
