### PR TITLE
Add stable/2024.1 to jammy-antelope

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -135,6 +135,7 @@
             branches:
               - stable/2023.1
               - stable/2023.2
+              - stable/2024.1
               - stable/1.8
               - stable/23.03
               - stable/quincy.2


### PR DESCRIPTION
It occurred to me that jammy-caracal charms need to support running
jammy-antelope to be able to do the SLURP release from antelope to
caracal.

Thus we add stable/2024.1 branch into the jammy-antelope job.
