### PR TITLE
Add jammy-antelope to charm-functional-tests project template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -133,6 +133,7 @@
               - stable/jammy
         - jammy-antelope:
             branches:
+              - master
               - stable/2023.1
               - stable/2023.2
               - stable/2024.1


### PR DESCRIPTION
This is needed as (currently) the slurp upgrade is from antelope ->
caracal and so charms need to be tested that they support running on
jammy-antelope on master.
