### PR TITLE
Update noble-caracal test jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -525,12 +525,13 @@
       - charm-build
     vars:
       tox_extra_args: '-- noble-caracal'
+      charmcraft_channel: '3.x/beta'
       # NOTE: the next two variables need to be updated together, because the
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      # juju_snap_channel: '3.1/stable'
-      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt'
+      juju_snap_channel: '3.5/stable'
+      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/noble.txt'
 - job:
     name: mantic-bobcat
     description: Run a functional test against mantic-bobcat

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -531,7 +531,7 @@
       # based on what snap channel is being used to bootstrap the controller
       # from.
       juju_snap_channel: '3.5/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/noble.txt'
+      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-noble.txt'
 - job:
     name: mantic-bobcat
     description: Run a functional test against mantic-bobcat

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -103,13 +103,9 @@
             branches:
               - main
               - master
-              - stable/2024.1  # OpenStack
-              - stable/24.03   # OVN
               - stable/noble   # Ubuntu
         - jammy-caracal:
             branches:
-              - main
-              - master
               - stable/2024.1  # OpenStack
               - stable/24.03   # OVN
               - stable/squid


### PR DESCRIPTION
Use charmcraft 3.x/beta for noble support on master/main branches. Only run the noble-caracal tests on the master/main branches.