### PR TITLE
Modify func-test-pr to work with globbed filenames

### DIFF
--- a/roles/handle-func-test-pr/tasks/main.yaml
+++ b/roles/handle-func-test-pr/tasks/main.yaml
@@ -23,9 +23,9 @@
   shell: |
     set -o pipefail
     {{ tmp_dir.path }}/process_func_test_pr.py \
-      -f "{{ zuul.project.src_dir }}/test-requirements.txt" \
-      -f "{{ zuul.project.src_dir }}/src/test-requirements.txt" \
-      -f "{{ zuul.project.src_dir }}/build/builds/{{ charm_name }}/test-requirements.txt" \
+      -f "{{ zuul.project.src_dir }}/test-requirements*.txt" \
+      -f "{{ zuul.project.src_dir }}/src/test-requirements*.txt" \
+      -f "{{ zuul.project.src_dir }}/build/builds/{{ charm_name }}/test-requirements*.txt" \
       {{ zuul.message }}
 
 

--- a/unit_tests/test_process_func_test_pr.py
+++ b/unit_tests/test_process_func_test_pr.py
@@ -111,6 +111,36 @@ class TestProcessFuncTestPR(unittest.TestCase):
                 ('Good morning, please may I have a savoury scone with '
                  'Béchamel sauce'))
 
+    def test_apply_updates_globbed(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            file1 = '{}/file.txt'.format(tmpdirname)
+            file2 = '{}/file2.txt'.format(tmpdirname)
+            globbed_name = '{}/file*.txt'.format(tmpdirname)
+            with open(file1, 'w') as f:
+                f.write("Yo, hit me with some biscuits and gravy")
+            with open(file2, 'w') as f:
+                f.write("Yo, hit me with some biscuits and gravy")
+            process_func_test_pr.apply_updates(
+                [
+                    ('Im not there', 'foo'),
+                    ('Yo,', 'Good morning,'),
+                    (r'hit.*with', 'please may I have'),
+                    ('some ', ''),
+                    (r'bis.*vy', 'a savoury scone with Béchamel sauce')],
+                [globbed_name])
+            with open(file1, 'r') as f:
+                contents = f.read()
+            self.assertEqual(
+                contents,
+                ('Good morning, please may I have a savoury scone with '
+                 'Béchamel sauce'))
+            with open(file2, 'r') as f:
+                contents = f.read()
+            self.assertEqual(
+                contents,
+                ('Good morning, please may I have a savoury scone with '
+                 'Béchamel sauce'))
+
     @mock.patch.object(process_func_test_pr.requests, 'get')
     def _test_process_func_test_pr(self, locations, mock_get):
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
The stable/X branches of OpenStack use python version specific
requirements files, in the form `requirements-pyX.txt`. The way that
func-test-pr was implemented limited scanning/updating files to those in
the form `requirements.txt`, etc.

This patch introduces globbing support, and then in the ansible
playbook, globbing for `requirements*.txt` rather to enable multiple
files to be updated via the func-test-pr.
