### PR TITLE
Charmcraft3: use jammy for building

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -212,8 +212,8 @@
       - serverstack_cloud
     nodeset:
       nodes:
-        - name: focal-medium
-          label: focal-medium
+        - name: jammy-medium
+          label: jammy-medium
 
 - job:
     name: configure-juju


### PR DESCRIPTION
Running into issues when building charms with charmcraft3 on focal. The symptom is failing systemd services such as

```
systemd-resolved.service: Failed to set up mount namespacing: /tmp:
Permission denied
```

Jammy does not have this issue.