### PR TITLE
Don't set juju snap channel and pip constraints

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -530,8 +530,8 @@
       # constraints have pinning to install the right version of python-libjuju
       # based on what snap channel is being used to bootstrap the controller
       # from.
-      juju_snap_channel: '3.5/stable'
-      pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-noble.txt'
+      # juju_snap_channel: '3.5/stable'
+      # pip_constraints_url: 'https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-noble.txt'
 - job:
     name: mantic-bobcat
     description: Run a functional test against mantic-bobcat


### PR DESCRIPTION
Use juju 2.9 in gate as we don't support newer Juju with Zaza yet

Depends-On: openstack-charmers/zaza#652