### PR TITLE
Don't run antelope functests for caracal branches

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -121,7 +121,6 @@
             branches:
               - stable/2023.1
               - stable/2023.2
-              - stable/2024.1
               - stable/1.8
               - stable/23.03
               - stable/quincy.2


### PR DESCRIPTION
Caracal branches need to run N and N-1 like other branches. Removing stable/2024.1 from jammy-antelope job.