### PR TITLE
Rewrite merged-requirements files in func-test-pr

### DIFF
--- a/roles/handle-func-test-pr/tasks/main.yaml
+++ b/roles/handle-func-test-pr/tasks/main.yaml
@@ -26,6 +26,9 @@
       -f "{{ zuul.project.src_dir }}/test-requirements*.txt" \
       -f "{{ zuul.project.src_dir }}/src/test-requirements*.txt" \
       -f "{{ zuul.project.src_dir }}/build/builds/{{ charm_name }}/test-requirements*.txt" \
+      -f "{{ zuul.project.src_dir }}/merged-requirements*.txt" \
+      -f "{{ zuul.project.src_dir }}/src/merged-requirements*.txt" \
+      -f "{{ zuul.project.src_dir }}/build/builds/{{ charm_name }}/merged-requirements*.txt" \
       {{ zuul.message }}
 
 


### PR DESCRIPTION
The func-test-pr role only rewrites test-requirements*.txt files.
Charms migrated to the ci-cleanup layout install their func-target tox env from merged-requirements-py*.txt via the base testenv, so rewriting test-requirements*.txt has no effect and the func-test-pr pin change never reaches the installed zaza.
Add merged-requirements*.txt to the globbed file list so the rewrite reaches the file that is actually installed.